### PR TITLE
feat(tabs): add render modes and improve accessibility

### DIFF
--- a/apps/docs/src/app/components/schema-editor/object/schema-editor-object.component.html
+++ b/apps/docs/src/app/components/schema-editor/object/schema-editor-object.component.html
@@ -5,7 +5,7 @@
     @for (schema of schemaList(); track schema.name) {
         <fkt-control-type-editor-cell
             [showLabel]="true"
-            [value]="value()?.[schema.name]"
+            [value]="value()[schema.name]"
             [schema]="schema.type.schema"
             [options]="schema.type.options"
             [type]="schema.type.type"

--- a/apps/docs/src/app/components/schema-editor/object/schema-editor-object.component.ts
+++ b/apps/docs/src/app/components/schema-editor/object/schema-editor-object.component.ts
@@ -1,11 +1,8 @@
-import { Component, computed, input, model, output } from '@angular/core';
-import { ArgTypeSchema, ArgTypeSchemaParsed } from '@/models/arg-type';
+import { Component, computed, input, model } from '@angular/core';
+import { ArgTypeSchema } from '@/models/arg-type';
 import { parseSchema } from '@/components/schema-editor/utils/parse-schema';
-import {
-    ControlTypeEditorCellComponent
-} from '@/components/control-type-editor-table-cell/control-type-editor-cell.component';
+import { ControlTypeEditorCellComponent } from '@/components/control-type-editor-table-cell/control-type-editor-cell.component';
 import { FktDividerComponent } from 'frakton-ng/divider';
-import { FktIconName } from 'frakton-ng/icon';
 
 @Component({
     selector: 'fkt-schema-editor-object',

--- a/apps/docs/src/app/pages/docs-page/tabs/docs-page-tabs.component.html
+++ b/apps/docs/src/app/pages/docs-page/tabs/docs-page-tabs.component.html
@@ -1,4 +1,4 @@
-<fkt-tabs-list hideTabsWhenOnlyOne (activeTabChange)="activeTabChange.emit($event)" [activeTab]="activeTab()">
+<fkt-tabs-list renderMode="destructive" hideTabsWhenOnlyOne (activeTabChange)="activeTabChange.emit($event!)" [activeTab]="activeTab()">
     <fkt-tab [hidden]="!isStoryType()" key="features" label="Features">
         @if (!loading()) {
             <fkt-features
@@ -26,9 +26,6 @@
 
 @if (loading()) {
     <div class="loading">
-        <fkt-skeleton-container>
-        </fkt-skeleton-container>
-
         <fkt-skeleton-container>
             <fkt-skeleton height="40px" width="200px" marginBottom="1rem"/>
             <fkt-skeleton height="20px" width="80%"/>

--- a/apps/docs/src/app/stories/button-group/examples/reactive-forms/button-group-reactive-forms.component.ts
+++ b/apps/docs/src/app/stories/button-group/examples/reactive-forms/button-group-reactive-forms.component.ts
@@ -1,16 +1,17 @@
 import { Component, inject } from '@angular/core';
-import { FktButtonGroupComponent, FktButtonGroupOption } from 'frakton-ng/button-group';
+import {
+    FktButtonGroupComponent,
+    FktButtonGroupOption,
+} from 'frakton-ng/button-group';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { FktButtonComponent } from 'frakton-ng/button';
-import { FktFieldErrorComponent } from 'frakton-ng/field-error';
 
 @Component({
     selector: 'fkt-button-group-reactive-forms',
     imports: [
         FktButtonGroupComponent,
         ReactiveFormsModule,
-        FktButtonComponent,
-        FktFieldErrorComponent
+        FktButtonComponent
     ],
     templateUrl: './button-group-reactive-forms.component.html',
     styleUrl: './button-group-reactive-forms.component.scss',

--- a/apps/docs/src/app/stories/tabs/examples/basic/tabs-basic.component.html
+++ b/apps/docs/src/app/stories/tabs/examples/basic/tabs-basic.component.html
@@ -1,0 +1,11 @@
+<fkt-tabs-list>
+    <fkt-tab key="overview" label="Overview">
+        <p>The overview tab is selected by default. Tab content is rendered lazily — other tabs are only created when first visited.</p>
+    </fkt-tab>
+    <fkt-tab key="features" label="Features">
+        <p>Once visited, this tab's content stays in the DOM. Switching away and back does not re-render it.</p>
+    </fkt-tab>
+    <fkt-tab key="usage" label="Usage">
+        <p>Use <code>[(activeTab)]</code> to control or read the selected tab from outside the component.</p>
+    </fkt-tab>
+</fkt-tabs-list>

--- a/apps/docs/src/app/stories/tabs/examples/basic/tabs-basic.component.scss
+++ b/apps/docs/src/app/stories/tabs/examples/basic/tabs-basic.component.scss
@@ -1,0 +1,13 @@
+p {
+    margin: 0;
+    color: var(--fkt-color-neutral-700);
+    font-size: var(--fkt-font-size-md);
+    line-height: 1.6;
+}
+
+code {
+    background: var(--fkt-color-neutral-100);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.9em;
+}

--- a/apps/docs/src/app/stories/tabs/examples/basic/tabs-basic.component.ts
+++ b/apps/docs/src/app/stories/tabs/examples/basic/tabs-basic.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { FktTabsListComponent, FktTabComponent } from 'frakton-ng/tabs';
+
+@Component({
+    selector: 'fkt-tabs-basic',
+    imports: [
+        FktTabsListComponent,
+        FktTabComponent,
+    ],
+    templateUrl: './tabs-basic.component.html',
+    styleUrl: './tabs-basic.component.scss',
+})
+export class TabsBasicComponent {}

--- a/apps/docs/src/app/stories/tabs/examples/raw-examples.ts
+++ b/apps/docs/src/app/stories/tabs/examples/raw-examples.ts
@@ -1,7 +1,90 @@
 // @ts-nocheck
 import { ExternalExample } from '@/models/external-example';
+import tabsBasicTemplate from "./basic/tabs-basic.component.html" with {loader: "text"};
+import tabsBasicStyles from "./basic/tabs-basic.component.scss" with {loader: "text"};
+import tabsBasicTypescript from "./basic/tabs-basic.component.ts" with {loader: "text"};
+import tabCounterTypescript from "./render-modes/tab-counter.component.ts" with {loader: "text"};
+import tabsRenderModesTemplate from "./render-modes/tabs-render-modes.component.html" with {loader: "text"};
+import tabsRenderModesStyles from "./render-modes/tabs-render-modes.component.scss" with {loader: "text"};
+import tabsRenderModesTypescript from "./render-modes/tabs-render-modes.component.ts" with {loader: "text"};
+import tabsWithIconsTemplate from "./with-icons/tabs-with-icons.component.html" with {loader: "text"};
+import tabsWithIconsStyles from "./with-icons/tabs-with-icons.component.scss" with {loader: "text"};
+import tabsWithIconsTypescript from "./with-icons/tabs-with-icons.component.ts" with {loader: "text"};
 
 
 export default {
-
+	TabsBasicComponent: {
+		name: "TabsBasic",
+		files: [
+		
+			{
+				name: "tabs-basic.component.html",
+				content: tabsBasicTemplate as string,
+				language: "html" as "html",
+			},		
+			{
+				name: "tabs-basic.component.ts",
+				content: tabsBasicTypescript as string,
+				language: "typescript" as "typescript",
+			},		
+			{
+				name: "tabs-basic.component.scss",
+				content: tabsBasicStyles as string,
+				language: "css" as "css",
+			},		
+		]
+	},
+	TabCounterComponent: {
+		name: "TabCounter",
+		files: [
+		
+			{
+				name: "tab-counter.component.ts",
+				content: tabCounterTypescript as string,
+				language: "typescript" as "typescript",
+			},		
+		]
+	},
+	TabsRenderModesComponent: {
+		name: "TabsRenderModes",
+		files: [
+		
+			{
+				name: "tabs-render-modes.component.html",
+				content: tabsRenderModesTemplate as string,
+				language: "html" as "html",
+			},		
+			{
+				name: "tabs-render-modes.component.ts",
+				content: tabsRenderModesTypescript as string,
+				language: "typescript" as "typescript",
+			},		
+			{
+				name: "tabs-render-modes.component.scss",
+				content: tabsRenderModesStyles as string,
+				language: "css" as "css",
+			},		
+		]
+	},
+	TabsWithIconsComponent: {
+		name: "TabsWithIcons",
+		files: [
+		
+			{
+				name: "tabs-with-icons.component.html",
+				content: tabsWithIconsTemplate as string,
+				language: "html" as "html",
+			},		
+			{
+				name: "tabs-with-icons.component.ts",
+				content: tabsWithIconsTypescript as string,
+				language: "typescript" as "typescript",
+			},		
+			{
+				name: "tabs-with-icons.component.scss",
+				content: tabsWithIconsStyles as string,
+				language: "css" as "css",
+			},		
+		]
+	},
 } as Record<string, ExternalExample>;

--- a/apps/docs/src/app/stories/tabs/examples/render-modes/tab-counter.component.ts
+++ b/apps/docs/src/app/stories/tabs/examples/render-modes/tab-counter.component.ts
@@ -1,0 +1,32 @@
+import { Component, signal } from '@angular/core';
+import { FktButtonComponent } from 'frakton-ng/button';
+
+@Component({
+    selector: 'fkt-tab-counter',
+    imports: [FktButtonComponent],
+    template: `
+        <div class="counter">
+            <p class="counter__value">Count: {{ count() }}</p>
+            <fkt-button size="sm" ariaLabel="Increment" icon="plus" (click)="increment()"/>
+        </div>
+    `,
+    styles: [`
+        .counter {
+            display: flex;
+            align-items: center;
+            gap: var(--fkt-space-md);
+        }
+        .counter__value {
+            margin: 0;
+            font-size: var(--fkt-font-size-md);
+            color: var(--fkt-color-neutral-700);
+        }
+    `]
+})
+export class TabCounterComponent {
+    protected count = signal(0);
+
+    protected increment() {
+        this.count.update(n => n + 1);
+    }
+}

--- a/apps/docs/src/app/stories/tabs/examples/render-modes/tabs-render-modes.component.html
+++ b/apps/docs/src/app/stories/tabs/examples/render-modes/tabs-render-modes.component.html
@@ -1,0 +1,71 @@
+<div class="demo">
+    <div class="demo__header">
+        <h3 class="demo__title">Lazy <fkt-tag color="info" text="default" class="demo__badge"></fkt-tag></h3>
+        <p class="demo__hint">Increment the counter, switch tabs, come back — count is preserved after first visit.</p>
+    </div>
+    <fkt-tabs-list renderMode="lazy">
+        <fkt-tab key="a" label="Tab A">
+            <ng-template fktTabLazy>
+                <fkt-tab-counter />
+            </ng-template>
+        </fkt-tab>
+        <fkt-tab key="b" label="Tab B">
+            <ng-template fktTabLazy>
+                <fkt-tab-counter />
+            </ng-template>
+        </fkt-tab>
+        <fkt-tab key="c" label="Tab C">
+            <ng-template fktTabLazy>
+                <fkt-tab-counter />
+            </ng-template>
+        </fkt-tab>
+    </fkt-tabs-list>
+</div>
+
+<div class="demo">
+    <div class="demo__header">
+        <h3 class="demo__title">Eager</h3>
+        <p class="demo__hint">All counters are rendered upfront. Count is always preserved regardless of visit order.</p>
+    </div>
+    <fkt-tabs-list renderMode="eager">
+        <fkt-tab key="a" label="Tab A">
+            <ng-template fktTabLazy>
+                <fkt-tab-counter />
+            </ng-template>
+        </fkt-tab>
+        <fkt-tab key="b" label="Tab B">
+            <ng-template fktTabLazy>
+                <fkt-tab-counter />
+            </ng-template>
+        </fkt-tab>
+        <fkt-tab key="c" label="Tab C">
+            <ng-template fktTabLazy>
+                <fkt-tab-counter />
+            </ng-template>
+        </fkt-tab>
+    </fkt-tabs-list>
+</div>
+
+<div class="demo">
+    <div class="demo__header">
+        <h3 class="demo__title">Destructive</h3>
+        <p class="demo__hint">Increment the counter, switch tabs, come back — count resets because the component is destroyed.</p>
+    </div>
+    <fkt-tabs-list renderMode="destructive">
+        <fkt-tab key="a" label="Tab A">
+            <ng-template fktTabLazy>
+                <fkt-tab-counter />
+            </ng-template>
+        </fkt-tab>
+        <fkt-tab key="b" label="Tab B">
+            <ng-template fktTabLazy>
+                <fkt-tab-counter />
+            </ng-template>
+        </fkt-tab>
+        <fkt-tab key="c" label="Tab C">
+            <ng-template fktTabLazy>
+                <fkt-tab-counter />
+            </ng-template>
+        </fkt-tab>
+    </fkt-tabs-list>
+</div>

--- a/apps/docs/src/app/stories/tabs/examples/render-modes/tabs-render-modes.component.scss
+++ b/apps/docs/src/app/stories/tabs/examples/render-modes/tabs-render-modes.component.scss
@@ -1,0 +1,42 @@
+.demo {
+    display: flex;
+    flex-direction: column;
+    gap: var(--fkt-space-sm);
+
+    & + .demo {
+        margin-top: var(--fkt-space-xl);
+        padding-top: var(--fkt-space-xl);
+        border-top: solid 1px var(--fkt-color-neutral-200);
+    }
+
+    &__header {
+        display: flex;
+        flex-direction: column;
+        gap: var(--fkt-space-xs);
+    }
+
+    &__title {
+        margin: 0;
+        font-size: var(--fkt-font-size-md);
+        font-weight: var(--fkt-font-semibold);
+        color: var(--fkt-color-neutral-900);
+        display: flex;
+        align-items: center;
+        gap: var(--fkt-space-xs);
+    }
+
+    &__badge {
+        font-size: var(--fkt-font-size-xs);
+        font-weight: var(--fkt-font-normal);
+        background: var(--fkt-color-neutral-100);
+        color: var(--fkt-color-neutral-600);
+        padding: 2px 8px;
+        border-radius: 99px;
+    }
+
+    &__hint {
+        margin: 0;
+        font-size: var(--fkt-font-size-sm);
+        color: var(--fkt-color-neutral-600);
+    }
+}

--- a/apps/docs/src/app/stories/tabs/examples/render-modes/tabs-render-modes.component.ts
+++ b/apps/docs/src/app/stories/tabs/examples/render-modes/tabs-render-modes.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { FktTabsListComponent, FktTabComponent, FktTabLazyDirective } from 'frakton-ng/tabs';
+import { TabCounterComponent } from './tab-counter.component';
+import { FktTagComponent } from 'frakton-ng/tag';
+
+@Component({
+    selector: 'fkt-tabs-render-modes',
+    imports: [
+        FktTabsListComponent,
+        FktTabComponent,
+        FktTabLazyDirective,
+        TabCounterComponent,
+        FktTagComponent,
+    ],
+    templateUrl: './tabs-render-modes.component.html',
+    styleUrl: './tabs-render-modes.component.scss',
+})
+export class TabsRenderModesComponent {}

--- a/apps/docs/src/app/stories/tabs/examples/with-icons/tabs-with-icons.component.html
+++ b/apps/docs/src/app/stories/tabs/examples/with-icons/tabs-with-icons.component.html
@@ -1,0 +1,11 @@
+<fkt-tabs-list>
+    <fkt-tab key="profile" label="Profile" icon="user">
+        <p>Manage your personal information and preferences.</p>
+    </fkt-tab>
+    <fkt-tab key="security" label="Security" icon="lock-closed">
+        <p>Configure password, two-factor authentication, and active sessions.</p>
+    </fkt-tab>
+    <fkt-tab key="notifications" label="Notifications" icon="bell">
+        <p>Choose which events trigger email or in-app notifications.</p>
+    </fkt-tab>
+</fkt-tabs-list>

--- a/apps/docs/src/app/stories/tabs/examples/with-icons/tabs-with-icons.component.scss
+++ b/apps/docs/src/app/stories/tabs/examples/with-icons/tabs-with-icons.component.scss
@@ -1,0 +1,6 @@
+p {
+    margin: 0;
+    color: var(--fkt-color-neutral-700);
+    font-size: var(--fkt-font-size-md);
+    line-height: 1.6;
+}

--- a/apps/docs/src/app/stories/tabs/examples/with-icons/tabs-with-icons.component.ts
+++ b/apps/docs/src/app/stories/tabs/examples/with-icons/tabs-with-icons.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { FktTabsListComponent, FktTabComponent } from 'frakton-ng/tabs';
+
+@Component({
+    selector: 'fkt-tabs-with-icons',
+    imports: [
+        FktTabsListComponent,
+        FktTabComponent,
+    ],
+    templateUrl: './tabs-with-icons.component.html',
+    styleUrl: './tabs-with-icons.component.scss',
+})
+export class TabsWithIconsComponent {}

--- a/apps/docs/src/app/stories/tabs/fkt-tabs.docs.md
+++ b/apps/docs/src/app/stories/tabs/fkt-tabs.docs.md
@@ -1,0 +1,47 @@
+## Key Features
+
+- Compound component pattern: `fkt-tabs-list` manages state, `fkt-tab` declares content
+- Three render modes: `destructive`, `lazy` (default), and `eager`
+- Signal-based active tab via `model<string>()` — two-way bindable with `[(activeTab)]`
+- Optional icons in tab headers via the `icon` input on `fkt-tab`
+- Tabs can be hidden dynamically via the `hidden` input
+- `hideTabsWhenOnlyOne` suppresses the header when only one tab is visible
+- Keyboard navigation via arrow keys (left/right)
+- ARIA roles: `role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`, `aria-labelledby`
+
+## Configuration Options
+
+<arg-types></arg-types>
+
+## Render Modes
+
+The `renderMode` input controls how tab content is managed in the DOM.
+
+| Mode | Behavior | Use when |
+|------|----------|----------|
+| `lazy` *(default)* | Content is rendered on first visit and kept in DOM | Best for most cases — preserves state, avoids upfront cost |
+| `eager` | All content is rendered immediately on mount | Content must be alive from the start (e.g., forms that track dirty state) |
+| `destructive` | Content is destroyed and recreated on every navigation | Content should always be fresh (e.g., data that reloads on entry) |
+
+> **Note on stateful content**: The render mode only affects components or templates declared inside `<ng-template fktTabLazy>`. Content projected directly as children of `<fkt-tab>` is part of the parent component's view and is not destroyed between navigations regardless of mode.
+
+## Usage
+
+```html
+<fkt-tabs-list [(activeTab)]="activeTab" renderMode="lazy">
+    <fkt-tab key="tab1" label="Tab 1">
+        <p>Tab 1 content</p>
+    </fkt-tab>
+    <fkt-tab key="tab2" label="Tab 2" [hidden]="someCondition">
+        <p>Tab 2 content</p>
+    </fkt-tab>
+</fkt-tabs-list>
+```
+
+## Accessibility
+
+- `role="tablist"` on the header container
+- `role="tab"` and `aria-selected` on each tab button
+- `role="tabpanel"` and `aria-labelledby` on each content panel, linked to its corresponding tab button via `id`
+- Arrow key navigation cycles through visible tabs
+- Tab key moves focus in and out of the tab list (not between tabs)

--- a/apps/docs/src/app/stories/tabs/fkt-tabs.stories.ts
+++ b/apps/docs/src/app/stories/tabs/fkt-tabs.stories.ts
@@ -1,0 +1,62 @@
+import { Meta } from '@/models/meta';
+import { FktTabsListComponent, fktTabsRenderModes } from 'frakton-ng/tabs';
+// @ts-expect-error
+import documentation from './fkt-tabs.docs.md' with { loader: 'text' };
+import { Story } from '@/models/story';
+import { DesignToken } from '@/models/design-token';
+import designTokens from './fkt-tabs-design-tokens.json';
+import { TabsBasicComponent } from '@/stories/tabs/examples/basic/tabs-basic.component';
+import { TabsRenderModesComponent } from '@/stories/tabs/examples/render-modes/tabs-render-modes.component';
+import { TabsWithIconsComponent } from '@/stories/tabs/examples/with-icons/tabs-with-icons.component';
+
+const meta: Meta<FktTabsListComponent> = {
+    title: "Components/Navigation/Tabs",
+    description: "A compound component for organising content into named panels, with lazy, eager, and destructive render strategies.",
+    designTokens: designTokens as DesignToken[],
+    component: FktTabsListComponent,
+    argTypes: {
+        activeTab: {
+            control: 'text',
+            type: 'string',
+            description: "Key of the currently selected tab. Bind with `[(activeTab)]` for two-way control. When unset, the first visible tab is selected automatically.",
+            category: "Attributes"
+        },
+        renderMode: {
+            control: 'select',
+            options: fktTabsRenderModes,
+            type: 'FktTabsRenderMode',
+            import: "import { FktTabsRenderMode } from 'frakton-ng/tabs'",
+            defaultValue: 'lazy',
+            description: "Controls how tab content is managed in the DOM. `lazy` (default) renders each panel on first visit and keeps it alive. `eager` renders all panels immediately. `destructive` destroys and recreates content on every navigation.",
+            category: "Attributes"
+        },
+        hideTabsWhenOnlyOne: {
+            control: 'boolean',
+            type: 'boolean',
+            defaultValue: 'false',
+            description: "Hides the tab header row when only one tab is visible, letting the content occupy the full space.",
+            category: "Attributes"
+        },
+    },
+    documentation
+}
+
+export const BasicUsage: Story<TabsBasicComponent> = {
+    component: TabsBasicComponent,
+    description: "Default tabs using lazy rendering. Content is created on first visit and kept in DOM when switching away.",
+    args: {}
+}
+
+export const WithIcons: Story<TabsWithIconsComponent> = {
+    component: TabsWithIconsComponent,
+    description: "Tab headers with icons alongside labels. Pass an icon name via the `icon` input on each `fkt-tab`.",
+    args: {}
+}
+
+export const RenderModes: Story<TabsRenderModesComponent> = {
+    component: TabsRenderModesComponent,
+    description: "Comparison of all three render modes. Each section uses `fktTabLazy` content with a counter component so state destruction and preservation are clearly visible when switching tabs.",
+    args: {}
+}
+
+export default meta;

--- a/libs/frakton-ng/tabs/public-api.ts
+++ b/libs/frakton-ng/tabs/public-api.ts
@@ -1,3 +1,5 @@
 export {FktTabsListComponent} from './src/fkt-tabs-list.component';
 export {FktTabComponent} from './src/tab/fkt-tab.component';
 export {FktTabLazyDirective} from './src/fkt-tab-lazy.directive';
+export {fktTabsRenderModes} from './src/fkt-tabs.types';
+export type {FktTabsRenderMode} from './src/fkt-tabs.types';

--- a/libs/frakton-ng/tabs/src/fkt-tabs-list.component.html
+++ b/libs/frakton-ng/tabs/src/fkt-tabs-list.component.html
@@ -1,11 +1,14 @@
 @if (!hideTabsWhenOnlyOne() || visibleTabs().length > 1) {
     <div fktNavigableList orientation="horizontal" (select)="keyboardSelect($event)" childSelector="button"
-         class="container">
+         role="tablist" class="container">
         @for (tab of visibleTabs(); track tab.key()) {
             <button
                 (click)="selectTab(tab.key())"
                 class="container__tab"
                 [class.container__tab--active]="tab.key() === activeTab()"
+                role="tab"
+                [id]="'fkt-tab-' + tab.key()"
+                [attr.aria-selected]="tab.key() === activeTab()"
             >
                 @if (tab.icon()) {
                     <fkt-icon [name]="tab.icon()!"/>
@@ -19,5 +22,15 @@
 }
 
 <div class="content">
-    <div #ref [style]="{display: 'none'}"></div>
+    @if (renderMode() === 'destructive') {
+        <div #ref role="tabpanel" [attr.aria-labelledby]="'fkt-tab-' + activeTab()"></div>
+    } @else {
+        @for (tab of tabsToRender(); track tab.key()) {
+            <fkt-tabs-renderer
+                [template]="tab.template()"
+                [tabKey]="tab.key()"
+                [hidden]="tab.key() !== activeTab()">
+            </fkt-tabs-renderer>
+        }
+    }
 </div>

--- a/libs/frakton-ng/tabs/src/fkt-tabs-list.component.scss
+++ b/libs/frakton-ng/tabs/src/fkt-tabs-list.component.scss
@@ -44,6 +44,7 @@ p {
 
 .content {
 	display: flex;
+    flex-direction: column;
 	width: 100%;
 	padding: var(--fkt-space-md);
 

--- a/libs/frakton-ng/tabs/src/fkt-tabs-list.component.ts
+++ b/libs/frakton-ng/tabs/src/fkt-tabs-list.component.ts
@@ -5,7 +5,8 @@ import {
     contentChildren,
     effect,
     input,
-    output,
+    model,
+    signal,
     untracked,
     viewChild,
     ViewContainerRef
@@ -14,91 +15,119 @@ import { FktIconComponent } from 'frakton-ng/icon';
 import { MarkUsed } from 'frakton-ng/internal/utils';
 import { FktTabComponent } from './tab/fkt-tab.component';
 import { FktNavigableListDirective } from 'frakton-ng/navigable-list';
+import { FktTabsRendererComponent } from './renderer/fkt-tabs-renderer.component';
+import { FktTabsRenderMode } from './fkt-tabs.types';
 
 @Component({
-	selector: 'fkt-tabs-list',
+    selector: 'fkt-tabs-list',
     imports: [
         FktIconComponent,
-        FktNavigableListDirective
+        FktNavigableListDirective,
+        FktTabsRendererComponent
     ],
-	templateUrl: './fkt-tabs-list.component.html',
-	styleUrl: './fkt-tabs-list.component.scss'
+    templateUrl: './fkt-tabs-list.component.html',
+    styleUrl: './fkt-tabs-list.component.scss'
 })
 export class FktTabsListComponent {
-	tabs = contentChildren(FktTabComponent);
-	activeTab = input<string>();
-	activeTabChange = output<string>();
-    lazyLoading = input(false, {
-        transform: booleanAttribute
-    })
+    tabs = contentChildren(FktTabComponent);
+    activeTab = model<string>();
+    renderMode = input<FktTabsRenderMode>('lazy');
     hideTabsWhenOnlyOne = input(false, {
         transform: booleanAttribute
-    })
+    });
 
     protected visibleTabs = computed(() => {
         this.tabs().forEach(a => a.hidden());
 
         return this.tabs().filter(tab => !tab.hidden());
-    })
+    });
 
-	protected activeTabComponent = computed(() => {
-		const activeTab = this.activeTab();
+    protected activeTabComponent = computed(() => {
+        const activeTab = this.activeTab();
 
-		if (!activeTab) return null;
+        if (!activeTab) return null;
 
-		return this.visibleTabs().find(tab => tab.key()===activeTab) ?? null;
-	});
+        return this.visibleTabs().find(tab => tab.key() === activeTab) ?? null;
+    });
 
-    private ref = viewChild.required("ref", {read: ViewContainerRef});
+    private visitedTabs = signal<Set<string>>(new Set());
+
+    protected tabsToRender = computed(() => {
+        const mode = this.renderMode();
+
+        if (mode === 'eager') return this.visibleTabs();
+
+        const activeTabKey = this.activeTab();
+        const visited = this.visitedTabs();
+
+        return this.visibleTabs().filter(
+            tab => visited.has(tab.key()) || tab.key() === activeTabKey
+        );
+    });
+
+    private ref = viewChild('ref', { read: ViewContainerRef });
 
     @MarkUsed()
     renderTab = effect(() => {
         const ref = this.ref();
 
+        if (!ref || this.renderMode() !== 'destructive') return;
+
         const currentComponent = this.activeTabComponent() ?? this.visibleTabs()[0];
 
-        if(!currentComponent) return;
+        if (!currentComponent) return;
 
-        this.ref().clear();
+        ref.clear();
 
         ref.createEmbeddedView(currentComponent.template());
-    })
+    });
 
-	@MarkUsed()
-	protected selectFirstTab = effect(() => {
-		const tabs = this.visibleTabs();
-		const activeTab = this.activeTab();
+    @MarkUsed()
+    protected trackVisited = effect(() => {
+        const activeTab = this.activeTab();
 
-		untracked(() => {
-			if (activeTab) return;
+        if (!activeTab || this.renderMode() === 'destructive') return;
 
-			if (!tabs.length) return;
+        untracked(() => {
+            this.visitedTabs.update(set => new Set([...set, activeTab]));
+        });
+    });
 
-			const firstTab = tabs[0];
+    @MarkUsed()
+    protected selectFirstTab = effect(() => {
+        const tabs = this.visibleTabs();
+        const activeTab = this.activeTab();
 
-			this.activeTabChange.emit(firstTab.key());
-		});
-	});
+        untracked(() => {
+            if (activeTab) return;
 
-	@MarkUsed()
-	protected verifyUnique = effect(() => {
-		const tabs = this.tabs();
+            if (!tabs.length) return;
 
-		untracked(() => {
-			const seen = new Set<string>();
-			for (const item of tabs) {
-				if (seen.has(item.key())) {
-					throw new Error(`Duplicate tab key: ${item.key()}`);
-				}
-				seen.add(item.key());
-			}
-			return true;
-		});
-	});
+            const firstTab = tabs[0];
 
-	selectTab(key: string) {
-		this.activeTabChange.emit(key);
-	}
+            this.activeTab.set(firstTab.key());
+        });
+    });
+
+    @MarkUsed()
+    protected verifyUnique = effect(() => {
+        const tabs = this.tabs();
+
+        untracked(() => {
+            const seen = new Set<string>();
+            for (const item of tabs) {
+                if (seen.has(item.key())) {
+                    throw new Error(`Duplicate tab key: ${item.key()}`);
+                }
+                seen.add(item.key());
+            }
+            return true;
+        });
+    });
+
+    selectTab(key: string) {
+        this.activeTab.set(key);
+    }
 
     keyboardSelect(index: number) {
         const tabs = this.visibleTabs();

--- a/libs/frakton-ng/tabs/src/fkt-tabs.types.ts
+++ b/libs/frakton-ng/tabs/src/fkt-tabs.types.ts
@@ -1,0 +1,2 @@
+export const fktTabsRenderModes = ['destructive', 'eager', 'lazy'] as const;
+export type FktTabsRenderMode = (typeof fktTabsRenderModes)[number];

--- a/libs/frakton-ng/tabs/src/renderer/fkt-tabs-renderer.component.ts
+++ b/libs/frakton-ng/tabs/src/renderer/fkt-tabs-renderer.component.ts
@@ -9,11 +9,13 @@ import { NgTemplateOutlet } from '@angular/common';
   templateUrl: './fkt-tabs-renderer.component.html',
   styleUrl: './fkt-tabs-renderer.component.scss',
     host: {
-      '[style.display]': 'hidden() ? "none" : "block"'
+      '[style.display]': 'hidden() ? "none" : "block"',
+      'role': 'tabpanel',
+      '[attr.aria-labelledby]': '"fkt-tab-" + tabKey()'
     }
 })
 export class FktTabsRendererComponent {
     template = input.required<TemplateRef<any>>();
     hidden = input(false);
-    showMode = input<'lazy' | 'eager'>('eager');
+    tabKey = input.required<string>();
 }


### PR DESCRIPTION
## Summary

- **Render modes** — novo input `renderMode` no `FktTabsListComponent` com 3 modos:
  - `lazy` (padrão): renderiza apenas as abas já visitadas (evita renderizar tudo de início)
  - `eager`: renderiza todas as abas de uma vez no DOM
  - `destructive`: destrói e recria o conteúdo a cada troca de aba (comportamento anterior)
- **Two-way binding** — `activeTab` migrado de `input/output` para `model<string>()`, simplificando o uso com `[(activeTab)]`
- **schema-editor fix** — remoção de imports não usados e correção de template binding
- **Docs** — stories e exemplos para tabs: básico, com ícones e demo de render-modes

## Commits

- `feat(tabs): add render modes, optimize rendering and improve accessibility`
- `fix(schema-editor): remove unused imports and fix template binding`
- `feat(docs/tabs): add tabs stories, examples, and render-mode demo`
- `fix(tabs): add renderMode, assert event, remove empty skeleton`

## Files changed (23 files, +544 / -78)

| Área | Mudanças |
|------|----------|
| `libs/frakton-ng/tabs/src/` | Core: render modes, model binding, visitedTabs signal |
| `apps/docs/src/app/stories/tabs/` | Stories + 3 exemplos novos (basic, with-icons, render-modes) |
| `apps/docs/src/app/stories/tabs/fkt-tabs.docs.md` | Documentação da API |
| `schema-editor` | Fix de imports e template binding |

## Test plan

- [ ] Verificar modo `lazy`: conteúdo de abas não visitadas não deve estar no DOM
- [ ] Verificar modo `eager`: todas as abas no DOM desde o início
- [ ] Verificar modo `destructive`: conteúdo destruído e recriado a cada troca
- [ ] Verificar two-way binding com `[(activeTab)]`
- [ ] Conferir docs/stories no app de documentação

🤖 Generated with [Claude Code](https://claude.com/claude-code)