### PR TITLE
feat(button-group): add orientation, ARIA toolbar and keyboard support

### DIFF
--- a/apps/docs/public/sitemap.xml
+++ b/apps/docs/public/sitemap.xml
@@ -40,7 +40,7 @@
         <loc>https://fraktonng.com/docs/button-group</loc>
         <priority>0.9</priority>
         <changefreq>weekly</changefreq>
-        <lastmod>2026-05-24T05:58:49.278Z</lastmod>
+        <lastmod>2026-05-24T06:38:00.490Z</lastmod>
     </url>
     <url>
         <loc>https://fraktonng.com/docs/buttons-list</loc>

--- a/apps/docs/src/app/components/schema-editor/object/schema-editor-object.component.html
+++ b/apps/docs/src/app/components/schema-editor/object/schema-editor-object.component.html
@@ -5,7 +5,7 @@
     @for (schema of schemaList(); track schema.name) {
         <fkt-control-type-editor-cell
             [showLabel]="true"
-            [value]="value()?.[schema.name]"
+            [value]="value()[schema.name]"
             [schema]="schema.type.schema"
             [options]="schema.type.options"
             [type]="schema.type.type"

--- a/apps/docs/src/app/stories/button-group/examples/input-driven/button-group-input-driven.component.html
+++ b/apps/docs/src/app/stories/button-group/examples/input-driven/button-group-input-driven.component.html
@@ -1,4 +1,21 @@
-<fkt-button-group
-    accessibleLabel="Filter"
-    [options]="options"
+<div>
+    <fkt-button-group
+        accessibleLabel="Filter"
+        [disabled]="disabled()"
+        [options]="options"
+        [(value)]="value"
+        [(touched)]="touched"
+        [invalid]="!value() && touched()"
+        deselectable
+    />
+    <fkt-field-error
+        [show]="!value() && touched()"
+        error="Field is required"
+    />
+</div>
+
+
+<fkt-button
+    text="Disable"
+    (click)="toggleDisabled()"
 />

--- a/apps/docs/src/app/stories/button-group/examples/input-driven/button-group-input-driven.component.scss
+++ b/apps/docs/src/app/stories/button-group/examples/input-driven/button-group-input-driven.component.scss
@@ -1,0 +1,5 @@
+:host {
+    display: flex;
+    flex-direction: column;
+    gap: var(--fkt-space-md);
+}

--- a/apps/docs/src/app/stories/button-group/examples/input-driven/button-group-input-driven.component.ts
+++ b/apps/docs/src/app/stories/button-group/examples/input-driven/button-group-input-driven.component.ts
@@ -1,33 +1,42 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { FktButtonGroupComponent, FktButtonGroupOption } from 'frakton-ng/button-group';
+import { FktButtonComponent } from 'frakton-ng/button';
+import { FktFieldErrorComponent } from 'frakton-ng/field-error';
 
 @Component({
-  selector: 'fkt-button-group-input-driven',
+    selector: 'fkt-button-group-input-driven',
     imports: [
-        FktButtonGroupComponent
+        FktButtonGroupComponent,
+        FktButtonComponent,
+        FktFieldErrorComponent,
     ],
-  templateUrl: './button-group-input-driven.component.html',
-  styleUrl: './button-group-input-driven.component.scss',
+    templateUrl: './button-group-input-driven.component.html',
+    styleUrl: './button-group-input-driven.component.scss',
 })
 export class ButtonGroupInputDrivenComponent {
-    options: FktButtonGroupOption[] = [
+    protected disabled = signal(false);
+    protected value = signal<string | null>(null);
+    protected touched = signal(false);
+
+    protected options: FktButtonGroupOption[] = [
         {
             id: 'list',
-            label: "List",
-            icon: 'list-bullet'
+            label: 'List',
+            icon: 'list-bullet',
         },
         {
             id: 'grid',
-            label: "Grid",
-            icon: 'squares-2x2'
+            label: 'Grid',
+            icon: 'squares-2x2',
         },
         {
             id: 'cards',
-            label: "Cards",
-            icon: 'square-3-stack-3d'
-        }
+            label: 'Cards',
+            icon: 'square-3-stack-3d',
+        },
     ];
 
-
-
+    protected toggleDisabled() {
+        this.disabled.update((value) => !value);
+    }
 }

--- a/apps/docs/src/app/stories/button-group/examples/reactive-forms/button-group-reactive-forms.component.html
+++ b/apps/docs/src/app/stories/button-group/examples/reactive-forms/button-group-reactive-forms.component.html
@@ -1,11 +1,19 @@
-<fkt-button-group
-    accessibleLabel="Filter"
-    [formControl]="form.controls.filter"
-    [options]="options"
-/>
+<div>
+    <fkt-button-group
+        accessibleLabel="Filter"
+        [formControl]="form.controls.filter"
+        [options]="options"
+        deselectable
+    />
+
+    <fkt-field-error
+        [show]="!!(fieldError$ | async)"
+        error="Field is required"
+    />
+</div>
 
 
 <fkt-button
     text="Disable"
-    (click)="disable()"
+    (click)="toggleDisabled()"
 />

--- a/apps/docs/src/app/stories/button-group/examples/reactive-forms/button-group-reactive-forms.component.ts
+++ b/apps/docs/src/app/stories/button-group/examples/reactive-forms/button-group-reactive-forms.component.ts
@@ -3,6 +3,8 @@ import { FktButtonGroupComponent, FktButtonGroupOption } from 'frakton-ng/button
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { FktButtonComponent } from 'frakton-ng/button';
 import { FktFieldErrorComponent } from 'frakton-ng/field-error';
+import { map } from 'rxjs';
+import { AsyncPipe } from '@angular/common';
 
 @Component({
     selector: 'fkt-button-group-reactive-forms',
@@ -10,36 +12,40 @@ import { FktFieldErrorComponent } from 'frakton-ng/field-error';
         FktButtonGroupComponent,
         ReactiveFormsModule,
         FktButtonComponent,
-        FktFieldErrorComponent
+        FktFieldErrorComponent,
+        AsyncPipe,
     ],
     templateUrl: './button-group-reactive-forms.component.html',
     styleUrl: './button-group-reactive-forms.component.scss',
 })
 export class ButtonGroupReactiveFormsComponent {
-    form = inject(FormBuilder).group({
-        filter: ['list', Validators.required]
-    })
+    protected form = inject(FormBuilder).group({
+        filter: [null as string | null, Validators.required],
+    });
 
-    options: FktButtonGroupOption[] = [
+    protected fieldError$ = this.form.controls.filter.statusChanges.pipe(
+        map(() => this.form.controls.filter.invalid && this.form.controls.filter.touched)
+    );
+
+    protected options: FktButtonGroupOption[] = [
         {
             id: 'list',
-            label: "List",
-            icon: 'list-bullet'
+            label: 'List',
+            icon: 'list-bullet',
         },
         {
             id: 'grid',
-            label: "Grid",
-            icon: 'squares-2x2'
+            label: 'Grid',
+            icon: 'squares-2x2',
         },
         {
             id: 'cards',
-            label: "Cards",
-            icon: 'square-3-stack-3d'
-        }
+            label: 'Cards',
+            icon: 'square-3-stack-3d',
+        },
     ];
 
-
-    disable() {
+    protected toggleDisabled() {
         if (this.form.controls.filter.disabled)
             this.form.controls.filter.enable();
         else this.form.controls.filter.disable();

--- a/apps/docs/src/app/stories/button-group/examples/signal-forms/button-group-signal-forms.component.html
+++ b/apps/docs/src/app/stories/button-group/examples/signal-forms/button-group-signal-forms.component.html
@@ -1,9 +1,17 @@
-<fkt-button-group
-    accessibleLabel="Filter"
-    [field]="form.filter"
-    [options]="options"
-/>
-<fkt-field-error
-    [show]="form.filter().invalid() && form.filter().touched()"
-    [error]="form.filter().errors()[0]?.message"
+<div>
+    <fkt-button-group
+        accessibleLabel="Filter"
+        [field]="form.filter"
+        [options]="options"
+        deselectable
+    />
+    <fkt-field-error
+        [show]="form.filter().invalid() && form.filter().touched()"
+        [error]="form.filter().errors()[0]?.message"
+    />
+</div>
+
+<fkt-button
+    text="Disable"
+    (click)="toggleDisabled()"
 />

--- a/apps/docs/src/app/stories/button-group/examples/signal-forms/button-group-signal-forms.component.scss
+++ b/apps/docs/src/app/stories/button-group/examples/signal-forms/button-group-signal-forms.component.scss
@@ -1,0 +1,5 @@
+:host {
+    display: flex;
+    flex-direction: column;
+    gap: var(--fkt-space-md);
+}

--- a/apps/docs/src/app/stories/button-group/examples/signal-forms/button-group-signal-forms.component.ts
+++ b/apps/docs/src/app/stories/button-group/examples/signal-forms/button-group-signal-forms.component.ts
@@ -1,45 +1,51 @@
 import { Component, signal } from '@angular/core';
 import { FktButtonGroupComponent, FktButtonGroupOption } from 'frakton-ng/button-group';
-import { Field, form, required } from '@angular/forms/signals';
+import { disabled, Field, form, required } from '@angular/forms/signals';
 import { FktFieldErrorComponent } from 'frakton-ng/field-error';
+import { FktButtonComponent } from 'frakton-ng/button';
 
 @Component({
-  selector: 'fkt-button-group-signal-forms',
+    selector: 'fkt-button-group-signal-forms',
     imports: [
         FktButtonGroupComponent,
         Field,
-        FktFieldErrorComponent
+        FktFieldErrorComponent,
+        FktButtonComponent,
     ],
-  templateUrl: './button-group-signal-forms.component.html',
-  styleUrl: './button-group-signal-forms.component.scss',
+    templateUrl: './button-group-signal-forms.component.html',
+    styleUrl: './button-group-signal-forms.component.scss',
 })
 export class ButtonGroupSignalFormsComponent {
     model = signal({
-        filter: 'list'
+        filter: null as string | null,
     });
 
-    form = form(this.model, path => {
-        required(path.filter, {message: "Field is required"});
+    private disabled = signal(false);
+
+    protected form = form(this.model, (path) => {
+        required(path.filter, { message: 'Field is required' });
+        disabled(path.filter, this.disabled);
     });
 
-    options: FktButtonGroupOption[] = [
+    protected options: FktButtonGroupOption[] = [
         {
             id: 'list',
-            label: "List",
-            icon: 'list-bullet'
+            label: 'List',
+            icon: 'list-bullet',
         },
         {
             id: 'grid',
-            label: "Grid",
-            icon: 'squares-2x2'
+            label: 'Grid',
+            icon: 'squares-2x2',
         },
         {
             id: 'cards',
-            label: "Cards",
-            icon: 'square-3-stack-3d'
-        }
+            label: 'Cards',
+            icon: 'square-3-stack-3d',
+        },
     ];
 
-
-
+    protected toggleDisabled() {
+        this.disabled.update((value) => !value);
+    }
 }

--- a/apps/docs/src/app/stories/button-group/fkt-button-group.stories.ts
+++ b/apps/docs/src/app/stories/button-group/fkt-button-group.stories.ts
@@ -1,5 +1,5 @@
 import { Meta } from '@/models/meta';
-import { FktButtonGroupComponent, fktButtonGroupShapes, fktButtonGroupSizes } from 'frakton-ng/button-group';
+import { FktButtonGroupComponent, fktButtonGroupOrientations, fktButtonGroupShapes, fktButtonGroupSizes } from 'frakton-ng/button-group';
 //@ts-expect-error
 import documentation from './fkt-button-group.docs.md' with { loader: 'text' };
 import { Story } from '@/models/story';
@@ -26,13 +26,20 @@ const meta: Meta<FktButtonGroupComponent> = {
             control: 'text',
             type: 'string',
             required: true,
-            description: "PLACEHOLDER",
+            description: "Sets the `aria-label` on the group host, describing its purpose to screen readers — required whenever no visible label is adjacent to the control.",
             category: "Attributes"
         },
         invalid: {
             control: 'boolean',
             type: 'boolean',
-            description: "PLACEHOLDER",
+            description: "Marks the control as invalid when used without a reactive or signal form. Combined with `touched`, it activates the error border styling on the buttons.",
+            category: "Attributes"
+        },
+        errors: {
+            control: 'array',
+            type: 'readonly WithOptionalField<ValidationError>[]',
+            import: "import { ValidationError, WithOptionalField } from '@angular/forms/signals'",
+            description: "Validation errors from a reactive or signal form. The first error's `message` is forwarded to `aria-errormessage` for screen readers. Rendering the message visually is the consumer's responsibility via `fkt-field-error`.",
             category: "Attributes"
         },
         options: {
@@ -103,6 +110,15 @@ const meta: Meta<FktButtonGroupComponent> = {
             options: fktButtonGroupSizes,
             import: "import {FktButtonGroupSize} from 'frakton-ng/button-group'"
         },
+        orientation: {
+            control: 'select',
+            category: 'Attributes',
+            type: 'FktButtonGroupOrientation',
+            description: 'Controls whether buttons are laid out side by side (`horizontal`) or stacked (`vertical`). Arrow key navigation adapts automatically to the chosen axis.',
+            defaultValue: 'horizontal',
+            options: fktButtonGroupOrientations,
+            import: "import {FktButtonGroupOrientation} from 'frakton-ng/button-group'"
+        },
 
     },
     documentation
@@ -135,7 +151,7 @@ export const BasicUsage: Story<FktButtonGroupComponent> = {
 }
 
 export const Multiple: Story<FktButtonGroupComponent> = {
-    description: "Single-select group with labeled icons and a predefined selection.",
+    description: "Multi-select mode allowing several options to be active simultaneously; `value` is an array of selected ids.",
     args: {
         accessibleLabel: "Filters",
         options: [
@@ -275,6 +291,43 @@ export const Sizes: Story<FktButtonGroupComponent> = {
     }
 }
 
+export const Orientations: Story<FktButtonGroupComponent> = {
+    description: "Compares horizontal and vertical layouts. Arrow key navigation adapts automatically: left/right for horizontal, up/down for vertical.",
+    args: {
+        accessibleLabel: "Filters",
+        options: [
+            {
+                id: 'list',
+                label: "List",
+                icon: 'list-bullet'
+            },
+            {
+                id: 'grid',
+                label: "Grid",
+                icon: 'squares-2x2'
+            },
+            {
+                id: 'cards',
+                label: "Cards",
+                icon: 'square-3-stack-3d'
+            }
+        ],
+    },
+    variants: {
+        orientation: 'vertical',
+        items: [
+            {
+                title: "Horizontal",
+                args: { orientation: 'horizontal' }
+            },
+            {
+                title: "Vertical",
+                args: { orientation: 'vertical' }
+            },
+        ]
+    }
+}
+
 export const OnlyLabels: Story<FktButtonGroupComponent> = {
     description: "Text-only buttons without icons for compact layouts.",
     args: {
@@ -374,19 +427,19 @@ export const OnlyIcons: Story<FktButtonGroupComponent> = {
 
 export const ReactiveForms: Story<ButtonGroupReactiveFormsComponent> = {
     component: ButtonGroupReactiveFormsComponent,
-    description: "PLACEHOLDER",
+    description: "Integration with Angular Reactive Forms via `formControl`. Demonstrates `Validators.required`, error display tied to control status, and toggling the disabled state programmatically.",
     args: {}
 }
 
 export const SignalForms: Story<ButtonGroupSignalFormsComponent> = {
     component: ButtonGroupSignalFormsComponent,
-    description: "PLACEHOLDER",
+    description: "Integration with the signal-based `@angular/forms/signals` API via the `[field]` binding. Shows required validation, signal-driven disabled state, and reactive error messages.",
     args: {}
 }
 
 export const InputDriven: Story<ButtonGroupInputDrivenComponent> = {
     component: ButtonGroupInputDrivenComponent,
-    description: "PLACEHOLDER",
+    description: "Manual signal-driven binding using `[(value)]` and `[(touched)]` two-way models without a form abstraction. Validation and error display are handled directly in the template.",
     args: {}
 }
 

--- a/apps/docs/src/app/stories/stories-map.ts
+++ b/apps/docs/src/app/stories/stories-map.ts
@@ -373,7 +373,7 @@ export const STORIES_MAP: StoryIndexer[] = [	{
 		        id: "multiple",
 		        name: "Multiple",
 		        componentName: null,
-		        description:  `Single-select group with labeled icons and a predefined selection.`,
+		        description:  `Multi-select mode allowing several options to be active simultaneously; \`value\` is an array of selected ids.`,
 		    },
 		    {
 		        id: "shapes",
@@ -386,6 +386,12 @@ export const STORIES_MAP: StoryIndexer[] = [	{
 		        name: "Sizes",
 		        componentName: null,
 		        description:  `Demonstrates how the control scales across the available size tokens.`,
+		    },
+		    {
+		        id: "orientations",
+		        name: "Orientations",
+		        componentName: null,
+		        description:  `Compares horizontal and vertical layouts. Arrow key navigation adapts automatically: left/right for horizontal, up/down for vertical.`,
 		    },
 		    {
 		        id: "only-labels",
@@ -403,19 +409,19 @@ export const STORIES_MAP: StoryIndexer[] = [	{
 		        id: "reactive-forms",
 		        name: "ReactiveForms",
 		        componentName: "ButtonGroupReactiveFormsComponent",
-		        description:  `PLACEHOLDER`,
+		        description:  `Integration with Angular Reactive Forms via \`formControl\`. Demonstrates \`Validators.required\`, error display tied to control status, and toggling the disabled state programmatically.`,
 		    },
 		    {
 		        id: "signal-forms",
 		        name: "SignalForms",
 		        componentName: "ButtonGroupSignalFormsComponent",
-		        description:  `PLACEHOLDER`,
+		        description:  `Integration with the signal-based \`@angular/forms/signals\` API via the \`[field]\` binding. Shows required validation, signal-driven disabled state, and reactive error messages.`,
 		    },
 		    {
 		        id: "input-driven",
 		        name: "InputDriven",
 		        componentName: "ButtonGroupInputDrivenComponent",
-		        description:  `PLACEHOLDER`,
+		        description:  `Manual signal-driven binding using \`[(value)]\` and \`[(touched)]\` two-way models without a form abstraction. Validation and error display are handled directly in the template.`,
 		    }
 	    ]
 	},

--- a/libs/frakton-ng/button-group/src/fkt-button-group.component.html
+++ b/libs/frakton-ng/button-group/src/fkt-button-group.component.html
@@ -1,9 +1,17 @@
-<div [class]="classes()">
+<div [class]="classes()" ngToolbar [orientation]="orientation()" [disabled]="disabled()">
     @for (option of options(); track option.id) {
-        <button [attr.aria-label]="option.label" (click)="toggle(option.id)"
+        <button ngToolbarWidget
+                [value]="option.id"
+                [disabled]="disabled()"
+                [attr.disabled]="disabled() ? '' : null"
+                [attr.aria-label]="option.label"
+                (click)="toggle(option.id)"
+                (keydown.enter)="$event.preventDefault(); toggle(option.id)"
+                (keydown.space)="$event.preventDefault(); toggle(option.id)"
                 [class.selected]="selectedOptions().includes(option.id)"
                 [class.disabled]="disabled()"
-                [class.invalid]="ngControl?.invalid ?? invalid()"
+                [class.invalid]="(ngControl?.invalid ?? invalid()) && touched()"
+                [attr.aria-pressed]="selectedOptions().includes(option.id)"
                 >
             @if (option.icon) {
                 <fkt-icon [name]="option.icon"/>
@@ -14,5 +22,3 @@
         </button>
     }
 </div>
-<!---->
-<!---->

--- a/libs/frakton-ng/button-group/src/fkt-button-group.component.scss
+++ b/libs/frakton-ng/button-group/src/fkt-button-group.component.scss
@@ -80,6 +80,45 @@ label {
         }
     }
 
+    &.shape-flat {
+        button {
+            border-radius: 0;
+        }
+    }
+
+    &.orientation-vertical {
+        flex-direction: column;
+
+        button:not(:last-child) {
+            border-right: solid 1px var(--fkt-color-neutral-400);
+            border-bottom: none;
+        }
+
+        button.invalid:not(.disabled) {
+            border-left-color: var(--fkt-color-danger);
+        }
+
+        &.shape-rounded {
+            button:first-child {
+                border-radius: var(--fkt-radius-full) var(--fkt-radius-full) 0 0;
+            }
+
+            button:last-child {
+                border-radius: 0 0 var(--fkt-radius-full) var(--fkt-radius-full);
+            }
+        }
+
+        &.shape-rect {
+            button:first-child {
+                border-radius: var(--fkt-radius-md) var(--fkt-radius-md) 0 0;
+            }
+
+            button:last-child {
+                border-radius: 0 0 var(--fkt-radius-md) var(--fkt-radius-md);
+            }
+        }
+    }
+
     &.size-xs {
         button {
             padding: var(--fkt-space-2xs) var(--fkt-space-xs);

--- a/libs/frakton-ng/button-group/src/fkt-button-group.component.ts
+++ b/libs/frakton-ng/button-group/src/fkt-button-group.component.ts
@@ -1,32 +1,39 @@
-import { booleanAttribute, Component, computed, inject, input, linkedSignal, model, signal } from '@angular/core';
-import { FktButtonGroupOption, FktButtonGroupShape, FktButtonGroupSize } from './fkt-button-group.types';
+import { booleanAttribute, Component, computed, inject, input, linkedSignal, model } from '@angular/core';
+import { FktButtonGroupOption, FktButtonGroupOrientation, FktButtonGroupShape, FktButtonGroupSize } from './fkt-button-group.types';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
-import { FormValueControl } from '@angular/forms/signals';
-import { provideCVA } from 'frakton-ng/internal/di';
+import { FormValueControl, ValidationError, WithOptionalField } from '@angular/forms/signals';
 import { FktIconComponent } from 'frakton-ng/icon';
+import { Toolbar, ToolbarWidget } from '@angular/aria/toolbar';
 
 @Component({
     selector: 'fkt-button-group',
     imports: [
-        FktIconComponent
+        FktIconComponent,
+        Toolbar,
+        ToolbarWidget,
     ],
     templateUrl: './fkt-button-group.component.html',
     styleUrl: './fkt-button-group.component.scss',
     host: {
         '(click)': "markAsTouched()",
-        '[attr.aria-label]': "accessibleLabel()"
+        '[attr.aria-label]': "accessibleLabel()",
+        '[attr.aria-invalid]': "ngControl?.invalid ?? invalid()",
+        '[attr.aria-errormessage]': "errors()[0]?.message",
+        'role': 'group'
     }
 })
 export class FktButtonGroupComponent implements ControlValueAccessor, FormValueControl<string[] | string | null> {
     value = model<string[] | string | null>(null)
     touched = model<boolean>(false)
     invalid = input(false);
+    errors = input<readonly WithOptionalField<ValidationError>[]>([]);
     disabled = model(false);
 
     accessibleLabel = input.required<string>();
     options = input.required<FktButtonGroupOption[]>();
     shape = input<FktButtonGroupShape>('rounded');
     size = input<FktButtonGroupSize>('md');
+    orientation = input<FktButtonGroupOrientation>('horizontal');
 
     deselectable = input(false, {
         transform: booleanAttribute
@@ -59,7 +66,6 @@ export class FktButtonGroupComponent implements ControlValueAccessor, FormValueC
     }
 
     writeValue(obj: string | null) {
-        console.log('Setting value', obj)
         this.value.set(obj);
     }
 
@@ -69,36 +75,37 @@ export class FktButtonGroupComponent implements ControlValueAccessor, FormValueC
     protected classes = computed(() => {
         const shape = this.shape();
         const size = this.size();
+        const orientation = this.orientation();
 
-        const classes: string[] = ['container'];
-
-        classes.push(`shape-${shape}`);
-        classes.push(`size-${size}`);
-
-        return classes.join(' ');
+        return ['container', `shape-${shape}`, `size-${size}`, `orientation-${orientation}`].join(' ');
     })
 
     protected toggle(value: string) {
         if(this.disabled()) return;
 
-        let currentValue = this.value();
+        const result = this.multiple() ? this.getMultipleToggled(value) : this.getSingleToggled(value);
 
-        if(this.multiple()) {
-            if(Array.isArray(currentValue)) {
-                if(currentValue.includes(value))
-                    currentValue = currentValue.filter(item => item !== value);
-                else
-                    currentValue.push(value);
-            }
-            else currentValue = [value];
-        }
-        else {
-            if(currentValue === value)
-                currentValue = null;
-            else currentValue = value
-        }
+        this.applyChanges(result);
+    }
 
-        this.applyChanges(currentValue);
+    private getMultipleToggled(value: string) {
+        const currentValue = this.value();
+
+        if(!Array.isArray(currentValue)) return [value];
+
+        if(currentValue.includes(value))
+            return currentValue.filter(item => item !== value);
+
+        return [...currentValue, value];
+    }
+
+    private getSingleToggled(value: string) {
+        const currentValue = this.value();
+
+        if(currentValue === value && this.deselectable())
+            return null;
+
+        return value;
     }
 
     protected markAsTouched() {
@@ -107,7 +114,7 @@ export class FktButtonGroupComponent implements ControlValueAccessor, FormValueC
     }
 
     private parseToArray(value: string[] | string | null) {
-        return Array.isArray(value) ? value : !!value ? [value] : [];
+        return Array.isArray(value) ? value : value ? [value] : [];
     }
 
     private applyChanges(value: string[] | string | null) {

--- a/libs/frakton-ng/button-group/src/fkt-button-group.types.ts
+++ b/libs/frakton-ng/button-group/src/fkt-button-group.types.ts
@@ -2,9 +2,11 @@ import { FktIconName } from 'frakton-ng/icon';
 
 export const fktButtonGroupShapes = ['rounded', 'rect', 'flat'] as const;
 export const fktButtonGroupSizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+export const fktButtonGroupOrientations = ['horizontal', 'vertical'] as const;
 
 export type FktButtonGroupShape = (typeof fktButtonGroupShapes)[number];
 export type FktButtonGroupSize = (typeof fktButtonGroupSizes)[number];
+export type FktButtonGroupOrientation = (typeof fktButtonGroupOrientations)[number];
 
 export interface FktButtonGroupOption {
     id: string;


### PR DESCRIPTION
## Summary

- **Orientação** — novo input `orientation: 'horizontal' | 'vertical'` no `FktButtonGroupComponent`
- **ARIA Toolbar** — integração com `@angular/aria/toolbar` (`Toolbar`, `ToolbarWidget`) para acessibilidade e navegação por teclado
- **Atributos ARIA** — adicionados `aria-invalid` e `aria-errormessage` no host; `role="group"` explícito
- **Erros** — novo input `errors` (`ValidationError[]`) para exibição de mensagens de erro
- **Toggle fix** — lógica de toggle extraída para `getMultipleToggled` / `getSingleToggled`; fix no deselect single-value
- **Docs** — stories e exemplos aprimorados com signals, forms e reactive forms; sitemap atualizado

## Commits

- `feat(button-group): add orientation, ARIA toolbar and keyboard support`
- `docs(button-group): enhance examples with signals, forms, and UI`
- `fix(docs): correct schema editor property access and update sitemap`

## Files changed (16 arquivos, +291 / -114)

| Área | Mudanças |
|------|----------|
| `libs/frakton-ng/button-group/src/` | Core: orientation, ARIA, errors input, toggle refactor |
| `apps/docs/src/app/stories/button-group/` | Stories + exemplos (input-driven, reactive-forms, signal-forms) |
| `apps/docs/public/sitemap.xml` | Sitemap atualizado |
| `schema-editor` | Fix de acesso a propriedade no template |

## Test plan

- [ ] Verificar orientação `horizontal` e `vertical` visualmente
- [ ] Navegar pelas opções com teclado (setas) via ARIA Toolbar
- [ ] Testar `aria-invalid` e `aria-errormessage` com um form inválido
- [ ] Confirmar que single-select com `deselectable` desseleciona corretamente
- [ ] Conferir docs/stories no app de documentação

🤖 Generated with [Claude Code](https://claude.com/claude-code)