### PR TITLE
feat(docs/skeleton): lazy story rendering, skeleton repeat/margin, story titles

### DIFF
--- a/apps/docs/src/app/components/markdown/markdown-wrapper.component.scss
+++ b/apps/docs/src/app/components/markdown/markdown-wrapper.component.scss
@@ -22,7 +22,7 @@
 
 
 markdown ::ng-deep {
-	font-size: var(--fkt-font-size-sm);
+	font-size: var(--fkt-font-size-md);
 	color: var(--fkt-color-neutral-900);
 
 	h2 {

--- a/apps/docs/src/app/components/story-renderer/story-renderer.component.html
+++ b/apps/docs/src/app/components/story-renderer/story-renderer.component.html
@@ -1,6 +1,4 @@
-<h3 [id]="storyId()">{{storyName() | pascalToHumanReadable}}</h3>
-
-<p>{{activeStory()?.description}}</p>
+<fkt-markdown [data]="activeStory()?.description ?? ''"/>
 
 <ng-template #playground>
     <fkt-playground/>
@@ -8,6 +6,5 @@
 
 @if (injector()) {
     <ng-container [ngTemplateOutlet]="playground" [ngTemplateOutletInjector]="injector()">
-
     </ng-container>
 }

--- a/apps/docs/src/app/components/story-renderer/story-renderer.component.ts
+++ b/apps/docs/src/app/components/story-renderer/story-renderer.component.ts
@@ -1,6 +1,5 @@
 import { Component, computed, inject, Injector, input } from '@angular/core';
 import { FktPlaygroundComponent } from '../playground/fkt-playground.component';
-import { PascalToHumanReadablePipe } from '@/pipes/pascal-to-human-readable.pipe';
 import { NgTemplateOutlet } from '@angular/common';
 import { StoryLoaderService } from '@/core/services/story-loader.service';
 import { STORY_INDEXER_TOKEN } from '@/tokens/story-indexer.token';
@@ -10,26 +9,22 @@ import { StoryResolved } from '@/models/story.resolved';
 import { ACTIVE_STORY_TOKEN } from '@/tokens/active-story.token';
 import { STORY_META_TOKEN } from '@/tokens/story-meta.token';
 import { ALL_STORIES_TOKEN } from '@/tokens/all-stories.token';
-import { pascalToKebab } from '@/utils/pascal-to-kebab';
+import { MarkdownWrapperComponent } from '@/components/markdown/markdown-wrapper.component';
 
 @Component({
-	selector: 'fkt-story-renderer',
+    selector: 'fkt-story-renderer',
     imports: [
         FktPlaygroundComponent,
-        PascalToHumanReadablePipe,
-        NgTemplateOutlet
+        NgTemplateOutlet,
+        MarkdownWrapperComponent,
     ],
-	templateUrl: './story-renderer.component.html',
-	styleUrl: './story-renderer.component.scss'
+    templateUrl: './story-renderer.component.html',
+    styleUrl: './story-renderer.component.scss',
 })
 export class StoryRendererComponent {
     storyName = input.required<string>();
-    indexer = input.required<StoryIndexer>()
-    storyResolved = input.required<StoryResolved>()
-
-    storyId = computed(() => {
-        return pascalToKebab(this.storyName());
-    })
+    indexer = input.required<StoryIndexer>();
+    storyResolved = input.required<StoryResolved>();
 
     private readonly loader = inject(StoryLoaderService);
 
@@ -45,7 +40,7 @@ export class StoryRendererComponent {
         const resolved = this.storyResolved();
         const activeStory = this.activeStory();
 
-        if(!activeStory || !indexer) return null;
+        if (!activeStory || !indexer) return null;
 
         return Injector.create({
             providers: [
@@ -67,12 +62,10 @@ export class StoryRendererComponent {
                 },
                 {
                     provide: ACTIVE_STORY_TOKEN,
-                    useValue: activeStory
+                    useValue: activeStory,
                 },
-                StoryInfoService
-            ]
-        })
-
-    })
-    protected readonly pascalToKebab = pascalToKebab;
+                StoryInfoService,
+            ],
+        });
+    });
 }

--- a/apps/docs/src/app/custom-elements/story-playground/story-examples.component.html
+++ b/apps/docs/src/app/custom-elements/story-playground/story-examples.component.html
@@ -3,10 +3,23 @@
 
 @if (indexer && resolved) {
     @for (story of stories(); track story.name) {
-        <fkt-story-renderer
-            [storyName]="story.name"
-            [indexer]="indexer"
-            [storyResolved]="resolved"
-        />
+        <h2 [id]="story.name | pascalToKebab">{{ story.name | pascalToHumanReadable }}</h2>
+
+        @defer (on viewport) {
+            <fkt-story-renderer
+                [storyName]="story.name"
+                [indexer]="indexer"
+                [storyResolved]="resolved"
+            />
+        } @placeholder {
+            <fkt-skeleton-container gap="0px">
+                <fkt-skeleton-container gap="3px" marginBottom="16px">
+                    <fkt-skeleton height="20px" width="100%"/>
+                    <fkt-skeleton height="20px" width="100%"/>
+                    <fkt-skeleton height="20px" width="100%"/>
+                </fkt-skeleton-container>
+                <fkt-skeleton height="632px" width="100%"/>
+            </fkt-skeleton-container>
+        }
     }
 }

--- a/apps/docs/src/app/custom-elements/story-playground/story-examples.component.ts
+++ b/apps/docs/src/app/custom-elements/story-playground/story-examples.component.ts
@@ -3,40 +3,47 @@ import { StoryLoaderService } from '@/core/services/story-loader.service';
 import { STORIES_MAP } from '@/stories/stories-map';
 import { StoryRendererComponent } from '@/components/story-renderer/story-renderer.component';
 import { injectRouteParams } from '@/utils/inject-route-params';
+import { FktSkeletonComponent, FktSkeletonContainerComponent } from 'frakton-ng/skeleton';
+import { PascalToHumanReadablePipe } from '@/pipes/pascal-to-human-readable.pipe';
+import { PascalToKebabPipe } from '@/pipes/pascal-to-kebab.pipe';
 
 
 @Component({
-	selector: 'fkt-story-examples',
+    selector: 'fkt-story-examples',
     imports: [
         StoryRendererComponent,
+        FktSkeletonComponent,
+        FktSkeletonContainerComponent,
+        PascalToHumanReadablePipe,
+        PascalToKebabPipe,
     ],
-	templateUrl: './story-examples.component.html',
-	styleUrl: './story-examples.component.scss'
+    templateUrl: './story-examples.component.html',
+    styleUrl: './story-examples.component.scss',
 })
 export class StoryExamplesComponent {
-	private loader = inject(StoryLoaderService);
+    private loader = inject(StoryLoaderService);
 
-	private readonly routeParams = injectRouteParams();
+    private readonly routeParams = injectRouteParams();
 
-	protected readonly storyIndexer = computed(() => {
-		const id = this.routeParams()['docId'];
+    protected readonly storyIndexer = computed(() => {
+        const id = this.routeParams()['docId'];
 
-		const story = STORIES_MAP.find(story => story.id === id);
+        const story = STORIES_MAP.find((story) => story.id === id);
 
-		return story ?? null;
-	});
+        return story ?? null;
+    });
 
-	protected readonly storyResolved = resource({
-		defaultValue: null,
-		params: this.storyIndexer,
-		loader: async ({params: story}) => {
-			if (!story) return null;
+    protected readonly storyResolved = resource({
+        defaultValue: null,
+        params: this.storyIndexer,
+        loader: async ({ params: story }) => {
+            if (!story) return null;
 
-			return (await this.loader.loadData(story)) ?? null;
-		}
-	});
+            return (await this.loader.loadData(story)) ?? null;
+        },
+    });
 
-	protected readonly stories = computed(() => {
-		return this.storyResolved.value()?.stories ?? [];
-	})
+    protected readonly stories = computed(() => {
+        return this.storyResolved.value()?.stories ?? [];
+    });
 }

--- a/apps/docs/src/app/pipes/pascal-to-kebab.pipe.ts
+++ b/apps/docs/src/app/pipes/pascal-to-kebab.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { pascalToHumanReadable } from '../utils/pascal-to-human-readable';
+import { pascalToKebab } from '@/utils/pascal-to-kebab';
+
+@Pipe({
+	name: 'pascalToKebab'
+})
+export class PascalToKebabPipe implements PipeTransform {
+	transform(value: string): string {
+		return pascalToKebab(value)
+	}
+}

--- a/libs/frakton-ng/skeleton/src/fkt-skeleton-container.component.ts
+++ b/libs/frakton-ng/skeleton/src/fkt-skeleton-container.component.ts
@@ -1,47 +1,58 @@
-import { Component, input } from '@angular/core';
+import { Component, computed, input, TemplateRef } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 
 export type FktSkeletonAlignment = 'start' | 'center' | 'end' | 'stretch' | 'space-between';
 export type FktSkeletonGap = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 @Component({
-	selector: 'fkt-skeleton-container',
-	imports: [],
-	template: '<ng-content/>',
-	styleUrl: './fkt-skeleton-container.component.scss',
-	host: {
-		'[style.flex-direction]': 'direction()',
-		'[style.justify-content]': 'justifyContent()',
-		'[style.align-items]': 'alignItems()',
-		'[style.gap]': 'computedGap()',
-		'[style.width]': 'width()',
-		'[style.height]': 'height()',
-	}
+    selector: 'fkt-skeleton-container',
+    imports: [NgTemplateOutlet],
+    template: `
+        @if (repeatTemplate()) { @for (content of repeatedContent(); track
+        content) {
+        <ng-container [ngTemplateOutlet]="repeatTemplate()" />
+        } } @else {
+        <ng-content />
+        }
+    `,
+    styleUrl: './fkt-skeleton-container.component.scss',
+    host: {
+        '[style.flex-direction]': 'direction()',
+        '[style.justify-content]': 'justifyContent()',
+        '[style.align-items]': 'alignItems()',
+        '[style.margin-bottom]': 'marginBottom()',
+        '[style.margin-top]': 'marginTop()',
+        '[style.gap]': 'gap()',
+        '[style.width]': 'width()',
+        '[style.height]': 'height()',
+        '[style.padding]': 'padding()',
+    },
 })
 export class FktSkeletonContainerComponent {
-	direction = input<'row' | 'column'>('column');
-	justify = input<FktSkeletonAlignment>('start');
-	align = input<FktSkeletonAlignment>('stretch');
-	gap = input<FktSkeletonGap>('sm');
-	width = input<string>('100%');
-	height = input<string>('auto');
+    marginBottom = input<string>('0px');
+    marginTop = input<string>('0px');
+    direction = input<'row' | 'column'>('column');
+    padding = input<string>('0');
+    justify = input<FktSkeletonAlignment>('start');
+    align = input<FktSkeletonAlignment>('stretch');
+    gap = input('.75rem');
+    width = input<string>('100%');
+    height = input<string>('auto');
+    repeatTemplate = input<TemplateRef<any>>();
+    repeatCount = input(1);
 
-	private gapMap: Record<FktSkeletonGap, string> = {
-		'xs': 'var(--fkt-space-xs)',
-		'sm': 'var(--fkt-space-sm)', 
-		'md': 'var(--fkt-space-md)',
-		'lg': 'var(--fkt-space-lg)',
-		'xl': 'var(--fkt-space-xl)'
-	};
+    private alignmentMap: Record<FktSkeletonAlignment, string> = {
+        start: 'flex-start',
+        center: 'center',
+        end: 'flex-end',
+        stretch: 'stretch',
+        'space-between': 'space-between',
+    };
 
-	private alignmentMap: Record<FktSkeletonAlignment, string> = {
-		'start': 'flex-start',
-		'center': 'center',
-		'end': 'flex-end',
-		'stretch': 'stretch',
-		'space-between': 'space-between'
-	};
+    justifyContent = () => this.alignmentMap[this.justify()];
+    alignItems = () => this.alignmentMap[this.align()];
 
-	computedGap = () => this.gapMap[this.gap()];
-	justifyContent = () => this.alignmentMap[this.justify()];
-	alignItems = () => this.alignmentMap[this.align()];
+    protected readonly repeatedContent = computed(() =>
+        new Array(this.repeatCount()).fill(null).map((_, index) => index)
+    );
 }

--- a/libs/frakton-ng/skeleton/src/fkt-skeleton.component.ts
+++ b/libs/frakton-ng/skeleton/src/fkt-skeleton.component.ts
@@ -13,6 +13,8 @@ import { FktSkeletonAnimation, FktSkeletonType } from './fkt-skeleton.types';
 		'[style.height]': 'computedHeight()',
 		'[style.min-height]': 'computedHeight()',
 		'[style.max-height]': 'computedHeight()',
+		'[style.margin-bottom]': 'marginBottom()',
+		'[style.margin-top]': 'marginTop()',
 		'[style.border-radius]': 'computedBorderRadius()',
 		'[style.aspect-ratio]': 'aspectRatio() || null',
 		'[class]': 'computedClasses()',
@@ -21,6 +23,8 @@ import { FktSkeletonAnimation, FktSkeletonType } from './fkt-skeleton.types';
 })
 export class FktSkeletonComponent {
 	width = input<string>('100%');
+	marginBottom = input<string>('0px');
+	marginTop = input<string>('0px');
 	height = input<string>();
 	type = input<FktSkeletonType>('rect');
 	animation = input<FktSkeletonAnimation>('shimmer');


### PR DESCRIPTION
## Summary

- **Lazy story rendering** — `StoryRendererComponent` refatorado para diferir a renderização das stories, reduzindo o trabalho inicial na página de docs
- **Story title em exemplos** — título da story agora exibido no cabeçalho dos exemplos via `story-examples.component`; novo pipe `PascalToKebabPipe`
- **Skeleton repeat** — `FktSkeletonContainerComponent` ganhou `repeatTemplate` + `repeatCount` para repetir um template N vezes sem duplicar HTML
- **Skeleton margin/padding** — inputs `marginTop`, `marginBottom` e `padding` adicionados ao container e `marginTop`/`marginBottom` ao `FktSkeletonComponent`
- **Skeleton gap flexível** — `gap` agora aceita qualquer string CSS (era enum `xs/sm/md/lg/xl`)
- **Markdown font size** — tamanho base do markdown aumentado para `md`

## Commits

- `feat(skeleton): add margin/padding inputs, flexible gap and repeat`
- `style(components/markdown): increase base markdown font size to medium`
- `feat(docs): defer story renderer and surface story title in examples`

## Files changed (8 arquivos, +126 / -89)

| Área | Mudanças |
|------|----------|
| `apps/docs/.../story-renderer/` | Lazy rendering, remoção de `pascalToKebab` inline |
| `apps/docs/.../story-playground/` | Exibição do título da story nos exemplos |
| `apps/docs/src/app/pipes/pascal-to-kebab.pipe.ts` | Novo pipe |
| `libs/frakton-ng/skeleton/src/` | repeat, margin, padding, gap livre |
| `apps/docs/.../markdown-wrapper.component.scss` | Font size aumentado |

## Test plan

- [ ] Verificar que as stories carregam de forma lazy na navegação da docs
- [ ] Confirmar que o título aparece corretamente no cabeçalho de cada exemplo
- [ ] Testar `repeatTemplate` + `repeatCount` no skeleton container
- [ ] Verificar `marginTop`, `marginBottom` e `padding` no container e no skeleton item
- [ ] Confirmar que `gap` aceita valores CSS arbitrários (ex: `1rem`, `8px`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)