### PR TITLE
feat(checkbox): add indeterminate state, tag no-wrap and dark theme fixes

### DIFF
--- a/libs/frakton-ng/assets/styles/themes/dark.css
+++ b/libs/frakton-ng/assets/styles/themes/dark.css
@@ -12,8 +12,8 @@
     --fkt-color-neutral-500: #64748b;
     --fkt-color-neutral-400: #475569;
     --fkt-color-neutral-300: #334155;
-    --fkt-color-neutral-200: #1e293b;
-    --fkt-color-neutral-100: #0f172a;
+    --fkt-color-neutral-200: #19202c;
+    --fkt-color-neutral-100: #151820;
     --fkt-color-neutral-50: #020617;
 
     --fkt-color-contrast-opacity-5: rgba(248, 250, 252, 0.05);

--- a/libs/frakton-ng/buttons-list/src/fkt-buttons-list.component.ts
+++ b/libs/frakton-ng/buttons-list/src/fkt-buttons-list.component.ts
@@ -5,10 +5,10 @@ import { FktButtonsListAlignment, FktButtonsListOrientation } from './fkt-button
 
 /**
  * A component that displays a list of buttons with configurable layout and alignment.
- * 
+ *
  * @example
  * ```html
- * <fkt-buttons-list 
+ * <fkt-buttons-list
  *   [actions]="buttonActions"
  *   [context]="userData"
  *   orientation="horizontal"
@@ -16,7 +16,7 @@ import { FktButtonsListAlignment, FktButtonsListOrientation } from './fkt-button
  *   horizontalAlignment="end">
  * </fkt-buttons-list>
  * ```
- * 
+ *
  * @example
  * ```typescript
  * export class MyComponent {
@@ -46,31 +46,31 @@ export class FktButtonsListComponent<T> {
 	 * Context object passed to button actions
 	 */
 	context = input<T>();
-	
+
 	/**
 	 * Layout orientation of the buttons
 	 * @default 'horizontal'
 	 */
-	orientation = input<FktButtonsListOrientation>('horizontal');
-	
+	orientation = input<FktButtonsListOrientation | undefined>('horizontal');
+
 	/**
 	 * Whether buttons should fill the available space
 	 * @default false
 	 */
 	fill = input(false, { transform: booleanAttribute });
-	
+
 	/**
 	 * Vertical alignment of buttons
 	 * @default 'start'
 	 */
-	verticalAlignment = input<FktButtonsListAlignment>('start');
-	
+	verticalAlignment = input<FktButtonsListAlignment | undefined>('start');
+
 	/**
 	 * Horizontal alignment of buttons
 	 * @default 'start'
 	 */
-	horizontalAlignment = input<FktButtonsListAlignment>('start');
-	
+	horizontalAlignment = input<FktButtonsListAlignment | undefined>('start');
+
 	/**
 	 * Array of button actions to display
 	 * @required

--- a/libs/frakton-ng/checkbox/src/fkt-checkbox.component.html
+++ b/libs/frakton-ng/checkbox/src/fkt-checkbox.component.html
@@ -2,6 +2,7 @@
 	[class.invalid]="invalid() && touched()"
 	[class.disabled]="disabled()">
 	<input
+		#checkboxInput
 		type="checkbox"
 		[disabled]="disabled()"
 		[checked]="checked()"
@@ -10,5 +11,5 @@
 		[attr.aria-errormessage]="errors()[0]?.message"
 		(change)="onChange($event)"
 	/>
-	<span >{{ label() }}</span>
+	<span>{{ label() }}</span>
 </label>

--- a/libs/frakton-ng/checkbox/src/fkt-checkbox.component.scss
+++ b/libs/frakton-ng/checkbox/src/fkt-checkbox.component.scss
@@ -169,6 +169,21 @@ label {
 			}
 		}
 
+		&:indeterminate {
+			background-color: $checked-background-color;
+			border-color: $checked-border-color;
+
+			&::before {
+				top: 50%;
+				left: 3px;
+				width: 8px;
+				height: 0;
+				border-right: none;
+				border-bottom: $checkmark-width solid $checkmark-color;
+				transform: translateY(-50%) scale(1);
+			}
+		}
+
     &:focus-visible {
       box-shadow: var(--fkt-focus-ring-shadow);
     }

--- a/libs/frakton-ng/checkbox/src/fkt-checkbox.component.ts
+++ b/libs/frakton-ng/checkbox/src/fkt-checkbox.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, model } from '@angular/core';
+import { Component, effect, ElementRef, input, model, viewChild } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FormCheckboxControl, ValidationError, WithOptionalField } from '@angular/forms/signals';
 
@@ -13,12 +13,21 @@ export class FktCheckboxComponent implements FormCheckboxControl {
 	touched = model(false);
 	disabled = input(false);
 	invalid = input(false);
+	indeterminate = input(false);
 	label = input('');
 	errors = input<readonly WithOptionalField<ValidationError>[]>([]);
 
+	private readonly checkboxInput = viewChild<ElementRef<HTMLInputElement>>('checkboxInput');
+
+	constructor() {
+		effect(() => {
+			const element = this.checkboxInput()?.nativeElement;
+			if (element) element.indeterminate = this.indeterminate();
+		});
+	}
+
 	protected onChange($event: Event) {
 		const target = $event.target as HTMLInputElement;
-
 		this.checked.set(target.checked);
 		this.touched.set(true);
 	}

--- a/libs/frakton-ng/tag/src/fkt-tag.component.scss
+++ b/libs/frakton-ng/tag/src/fkt-tag.component.scss
@@ -202,6 +202,7 @@ $tag-success-faded-background: var(--fkt-tag-success-faded-background, var(--fkt
 	padding: $tag-padding;
 	font-weight: $tag-font-weight;
 	font-size: $tag-font-size;
+    white-space: nowrap;
 
 	&.badge--opaque {
 		&.badge--danger {


### PR DESCRIPTION
## Summary

- **Checkbox indeterminate** — `FktCheckboxComponent` agora suporta estado indeterminate via novo input `indeterminate`, com estilo dedicado no SCSS
- **Tag no-wrap** — `fkt-tag` com `white-space: nowrap` para evitar quebra de linha no texto
- **buttons-list fix** — inputs aceitam `undefined` e espaçamento corrigido
- **Dark theme** — tokens de cor neutral atualizados no tema escuro

## Commits

- `style(theme/dark): update neutral color tokens in dark theme`
- `refactor(buttons-list): accept undefined inputs and fix spacing`
- `fix(tag): prevent tag text from wrapping`
- `feat(checkbox): add indeterminate state support`

## Files changed (6 arquivos, +42 / -16)

| Área | Mudanças |
|------|----------|
| `libs/frakton-ng/checkbox/src/` | Input `indeterminate`, template e estilos |
| `libs/frakton-ng/tag/src/` | `white-space: nowrap` |
| `libs/frakton-ng/buttons-list/src/` | Inputs opcionais e espaçamento |
| `libs/frakton-ng/assets/styles/themes/dark.css` | Tokens neutral corrigidos |

## Test plan

- [ ] Verificar checkbox com `[indeterminate]="true"` exibe o estado visual correto
- [ ] Confirmar que o estado indeterminate some ao clicar
- [ ] Testar tag com texto longo — não deve quebrar linha
- [ ] Verificar cores neutral no tema escuro

🤖 Generated with [Claude Code](https://claude.com/claude-code)