### PR TITLE
Refine docs playground anatomy and token navigation

### DIFF
--- a/apps/docs/src/app/components/playground/components/design-tokens/info/design-token-info.component.scss
+++ b/apps/docs/src/app/components/playground/components/design-tokens/info/design-token-info.component.scss
@@ -4,6 +4,10 @@
     gap: var(--fkt-space-md);
     padding: 1rem;
     width: 400px;
+
+    * {
+        color: var(--fkt-color-neutral-800);
+    }
 }
 
 .header {

--- a/apps/docs/src/app/components/playground/components/design-tokens/item/story-design-tokens-item.component.scss
+++ b/apps/docs/src/app/components/playground/components/design-tokens/item/story-design-tokens-item.component.scss
@@ -30,6 +30,11 @@
 
         display: flex;
         gap: var(--fkt-space-xs);
+        outline: none;
+
+        &:focus-visible {
+            box-shadow: var(--fkt-focus-ring-shadow);
+        }
     }
 }
 

--- a/apps/docs/src/app/components/playground/components/design-tokens/story-design-tokens.component.html
+++ b/apps/docs/src/app/components/playground/components/design-tokens/story-design-tokens.component.html
@@ -1,9 +1,13 @@
 @if (scopes().length > 2) {
-    <div class="component-container">
+    <div fktNavigableList orientation="horizontal" childSelector=".scope" (select)="selectScopeByIndex($event)" class="scopes-container">
         @for (scope of scopes(); track scope) {
             <button
                 [class.active]="currentScope() === scope"
-                (click)="currentScope.set(scope)" class="component">
+                (mouseenter)="showAnatomy(scope)"
+                (focus)="showAnatomy(scope)"
+                (blur)="target.set(null)"
+                (mouseout)="target.set(null)"
+                (click)="currentScope.set(scope)" class="scope">
                 {{ scope.name }}
             </button>
         }
@@ -20,3 +24,15 @@
         }
     }
 </div>
+
+@if (anatomyInfo(); as info) {
+    <div class="anatomy"
+         [style.top.px]="info.y"
+         [style.left.px]="info.x">
+        <span class="label">{{ target()?.name }}</span>
+        <div class="range"
+             [style.width.px]="info.width"
+             [style.height.px]="info.height">
+        </div>
+    </div>
+}

--- a/apps/docs/src/app/components/playground/components/design-tokens/story-design-tokens.component.scss
+++ b/apps/docs/src/app/components/playground/components/design-tokens/story-design-tokens.component.scss
@@ -30,7 +30,7 @@
     right: -.3rem;
 }
 
-.component-container {
+.scopes-container {
     display: flex;
     gap: var(--fkt-space-xs);
     padding: var(--fkt-space-xs) var(--fkt-space-md);
@@ -40,7 +40,7 @@
     overflow: auto;
     border-bottom: 1px solid var(--fkt-controls-table-border-color);
 
-    .component {
+    .scope {
         position: relative;
         outline: none;
         padding: .5rem .75rem;
@@ -57,9 +57,39 @@
             color: var(--fkt-controls-table-component-active-text-color);
         }
 
+        &:focus-visible {
+            box-shadow: var(--fkt-focus-ring-shadow);
+        }
+
         &:hover:not(.active) {
             background-color: rgb(from var(--fkt-color-primary) r g b / .2);
         }
+    }
+}
+
+.anatomy {
+    position: absolute;
+    z-index: 100000;
+
+    --anatomy-color: var(--fkt-color-danger);
+
+    .range {
+        border: solid 1px var(--anatomy-color);
+        background: rgb(from var(--anatomy-color) r g b / 0.1);
+        border-radius: 0 var(--fkt-radius-md) var(--fkt-radius-md) var(--fkt-radius-md);
+    }
+
+    .label {
+        position: absolute;
+        top: 0;
+        left: 0;
+        transform: translateY(-100%);
+        font-size: var(--fkt-font-size-sm);
+        background: var(--anatomy-color);
+        color: white;
+        padding: var(--fkt-space-4xs) var(--fkt-space-xs);
+        font-weight: var(--fkt-font-semibold);
+        border-radius: var(--fkt-radius-md) var(--fkt-radius-md) 0 0;
     }
 }
 
@@ -68,6 +98,9 @@
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: var(--fkt-space-md);
     padding: var(--fkt-space-md);
+
+    max-height: 500px;
+    overflow-y: auto;
 }
 
 .tables {

--- a/apps/docs/src/app/components/playground/components/design-tokens/story-design-tokens.component.ts
+++ b/apps/docs/src/app/components/playground/components/design-tokens/story-design-tokens.component.ts
@@ -5,20 +5,24 @@ import {
     input,
     linkedSignal,
     reflectComponentType,
+    signal,
 } from '@angular/core';
 import { DesignTokenItem } from '@/models/design-token-item';
 import { StoryDesignTokensItemComponent } from './item/story-design-tokens-item.component';
 import { FktIconName } from 'frakton-ng/icon';
 import { STORY_META_TOKEN } from '@/tokens/story-meta.token';
+import { getVisibleRect } from '@/utils/get-visible-rect';
+import { FktNavigableListDirective } from 'frakton-ng/navigable-list';
 
 @Component({
     selector: 'app-story-design-tokens',
-    imports: [StoryDesignTokensItemComponent],
+    imports: [StoryDesignTokensItemComponent, FktNavigableListDirective],
     templateUrl: './story-design-tokens.component.html',
     styleUrl: './story-design-tokens.component.scss',
 })
 export class StoryDesignTokensComponent {
     designTokens = input.required<DesignTokenItem[]>();
+    parentContainer = input<HTMLElement>();
 
     private meta = inject(STORY_META_TOKEN);
 
@@ -36,6 +40,26 @@ export class StoryDesignTokensComponent {
         }
     });
 
+    protected readonly target = signal<null | {
+        name: string;
+        rect: DOMRect;
+    }>(null);
+
+    protected anatomyInfo = computed(() => {
+        const target = this.target();
+
+        if (!target) return null;
+
+        const bounds = target.rect;
+
+        return {
+            width: bounds.width,
+            height: bounds.height,
+            x: bounds.left,
+            y: bounds.top,
+        };
+    });
+
     protected readonly currentScope = linkedSignal(() => {
         const components = this.scopes();
 
@@ -45,18 +69,29 @@ export class StoryDesignTokensComponent {
     protected readonly scopes = computed(() => {
         const tokens = this.designTokens();
 
-        const scopes: {name: string; tokens: DesignTokenItem[] }[] = [{name: 'All', tokens}];
+        const scopes: {
+            name: string;
+            selector: string | null;
+            tokens: DesignTokenItem[];
+        }[] = [{ name: 'All', selector: this.templateSelector(), tokens }];
 
         tokens.forEach((token) => {
-            if (!token.component) return;
+            const scopeName = token.scope?.name ?? token.component;
+            const scopeSelector = token.scope?.selector ?? null;
+
+            if (!scopeName) return;
 
             const scopeRegistered = scopes.find(
-                (scope) => scope.name === token.component
+                (scope) => scope.name === scopeName
             );
 
-            if(scopeRegistered)
-                scopeRegistered.tokens.push(token)
-            else scopes.push({name: token.component, tokens: [token]})
+            if (scopeRegistered) scopeRegistered.tokens.push(token);
+            else
+                scopes.push({
+                    name: scopeName,
+                    selector: scopeSelector,
+                    tokens: [token],
+                });
         });
 
         return scopes;
@@ -109,4 +144,46 @@ export class StoryDesignTokensComponent {
 
         return categories.filter((category) => category.tokens.length > 0);
     });
+
+    protected showAnatomy(scope: {
+        name: string;
+        selector: string | null;
+        tokens: DesignTokenItem[];
+    }) {
+        const selector = scope.selector;
+        const container = this.parentContainer();
+
+        if (!selector || !container) return;
+
+        const element = container.querySelector(selector) ?? null;
+
+        const elements = Array.from(
+            container.querySelectorAll<HTMLElement>(selector)
+        );
+
+        const visibleRects = [...elements]
+            .map((element) => getVisibleRect(element, container))
+            .filter((rect) => !!rect);
+
+        const middleIndex = Math.ceil(visibleRects.length / 2) - 1;
+
+        const middleRect = visibleRects[middleIndex];
+
+        if (element && middleRect)
+            this.target.set({
+                name: scope.name,
+                rect: middleRect,
+            });
+        else this.target.set(null);
+    }
+
+    protected selectScopeByIndex($event: number) {
+        const newScope = this.scopes()[$event ?? -1];
+        console.log(newScope, $event);
+
+        if(!newScope) return;
+
+        this.currentScope.set(newScope);
+    }
 }
+

--- a/apps/docs/src/app/components/playground/components/panel/story-panel.component.html
+++ b/apps/docs/src/app/components/playground/components/panel/story-panel.component.html
@@ -1,8 +1,8 @@
 <div>
     <div class="tabs">
         <div fktNavigableList orientation="horizontal" (select)="selectTabByIndex($event)" childSelector="button"
-            class="tabs__list"
-            role="tablist">
+             class="tabs__list"
+             role="tablist">
             @for (tab of visibleTabs(); track tab.key) {
                 <button
                     class="tab"
@@ -18,7 +18,6 @@
             }
         </div>
     </div>
-
 
     @if (currentTab() === "controls" && canShowControls()) {
         <div role="tabpanel" id="panel-controls" aria-labelledby="tab-controls">
@@ -139,7 +138,7 @@
     }
     @if (currentTab() === "styling" && canShowDesignTokens()) {
         <div role="tabpanel" id="panel-styling" aria-labelledby="tab-styling">
-            <app-story-design-tokens [designTokens]="designTokens()"/>
+            <app-story-design-tokens [parentContainer]="parentRef.nativeElement" [designTokens]="designTokens()"/>
         </div>
     }
     @if (currentTab() === "code") {

--- a/apps/docs/src/app/components/playground/components/panel/story-panel.component.scss
+++ b/apps/docs/src/app/components/playground/components/panel/story-panel.component.scss
@@ -78,6 +78,10 @@
             background: var(--fkt-color-primary-opacity-20);
         }
 
+        &:focus-visible {
+            box-shadow: var(--fkt-focus-ring-shadow);
+        }
+
         fkt-icon {
             font-weight: lighter;
         }

--- a/apps/docs/src/app/components/playground/components/panel/story-panel.component.ts
+++ b/apps/docs/src/app/components/playground/components/panel/story-panel.component.ts
@@ -1,6 +1,8 @@
 import {
+    afterNextRender,
     Component,
-    computed,
+    computed, effect,
+    ElementRef, inject,
     input,
     linkedSignal,
     signal,
@@ -42,8 +44,17 @@ interface Tab {
 })
 export class StoryPanelComponent {
     argsList = input.required<ArgItem<any>[]>();
+    container = input<HTMLElement>();
     designTokens = input.required<DesignTokenItem[]>();
     protected readonly activeControlsOwner = signal('all');
+
+    a = signal<string | null>(null)
+
+    protected readonly parentRef = inject(ElementRef, {skipSelf: true})
+
+    ab = afterNextRender(() => {
+        this.a.set(this.parentRef.nativeElement.innerHTML);
+    })
 
     protected currentTab = linkedSignal<string>(() => {
         const tabs = this.visibleTabs();
@@ -119,7 +130,7 @@ export class StoryPanelComponent {
     });
 
     protected selectTabByIndex($event: number | null) {
-        const tab = this.tabs()[$event ?? -1];
+        const tab = this.visibleTabs()[$event ?? -1];
 
         if (!tab) return;
 

--- a/apps/docs/src/app/components/playground/components/panel/story-panel.component.ts
+++ b/apps/docs/src/app/components/playground/components/panel/story-panel.component.ts
@@ -48,13 +48,7 @@ export class StoryPanelComponent {
     designTokens = input.required<DesignTokenItem[]>();
     protected readonly activeControlsOwner = signal('all');
 
-    a = signal<string | null>(null)
-
     protected readonly parentRef = inject(ElementRef, {skipSelf: true})
-
-    ab = afterNextRender(() => {
-        this.a.set(this.parentRef.nativeElement.innerHTML);
-    })
 
     protected currentTab = linkedSignal<string>(() => {
         const tabs = this.visibleTabs();

--- a/apps/docs/src/app/stories/table/fkt-table-design-tokens.json
+++ b/apps/docs/src/app/stories/table/fkt-table-design-tokens.json
@@ -16,8 +16,8 @@
     "description": "Background color for table container.",
     "name": "--fkt-table-cell-background",
     "reference": "--fkt-color-neutral-100",
-    "category": "Color",
-    "type": "size",
+    "category": "Colors",
+    "type": "color",
     "defaultValue": "#f1f5f9",
     "component": "Table",
     "scope": {

--- a/apps/docs/src/app/utils/get-visible-rect.ts
+++ b/apps/docs/src/app/utils/get-visible-rect.ts
@@ -1,0 +1,34 @@
+import { intersectRects } from '@/utils/intersect-rects';
+
+export function getVisibleRect(
+    element: HTMLElement,
+    root: HTMLElement
+): DOMRect | null {
+    let rect: DOMRect | null = element.getBoundingClientRect();
+
+    let parent = element.parentElement;
+
+    while (parent && parent !== root.parentElement) {
+        const style = getComputedStyle(parent);
+
+        const clips =
+            ['auto', 'scroll', 'hidden', 'clip'].includes(style.overflow) ||
+            ['auto', 'scroll', 'hidden', 'clip'].includes(style.overflowX) ||
+            ['auto', 'scroll', 'hidden', 'clip'].includes(style.overflowY);
+
+        if (clips) {
+            const parentRect = parent.getBoundingClientRect();
+
+            rect = intersectRects(rect, parentRect);
+
+            if (!rect) return null;
+        }
+
+        if (parent === root) break;
+
+        parent = parent.parentElement;
+    }
+
+    return rect;
+}
+

--- a/apps/docs/src/app/utils/intersect-rects.ts
+++ b/apps/docs/src/app/utils/intersect-rects.ts
@@ -1,0 +1,10 @@
+export function intersectRects(first: DOMRect, second: DOMRect): DOMRect | null {
+    const left = Math.max(first.left, second.left);
+    const top = Math.max(first.top, second.top);
+    const right = Math.min(first.right, second.right);
+    const bottom = Math.min(first.bottom, second.bottom);
+
+    if (right <= left || bottom <= top) return null;
+
+    return new DOMRect(left, top, right - left, bottom - top);
+}

--- a/libs/frakton-ng/navigable-list/src/fkt-navigable-list.directive.ts
+++ b/libs/frakton-ng/navigable-list/src/fkt-navigable-list.directive.ts
@@ -23,22 +23,22 @@ export class FktNavigableListDirective implements AfterViewInit {
 			case 'ArrowDown':
 				if(orientation !== "vertical") break;
 				event.preventDefault();
-				this.currentIndex.update(index => clampNumber((index ?? -1) + 1, 0, this.elements().length - 1));
+				this.currentIndex.update(index => clampNumber((index ?? 0) + 1, 0, this.elements().length - 1));
 				break;
 			case 'ArrowUp':
 				if(orientation !== "vertical") break;
 				event.preventDefault();
-				this.currentIndex.update(index => clampNumber((index ?? 1) - 1, 0, this.elements().length - 1));
+				this.currentIndex.update(index => clampNumber((index ?? 0) - 1, 0, this.elements().length - 1));
 				break;
 			case 'ArrowLeft':
 				if(orientation !== "horizontal") break;
 				event.preventDefault();
-				this.currentIndex.update(index => clampNumber((index ?? 1) - 1, 0, this.elements().length - 1));
+				this.currentIndex.update(index => clampNumber((index ?? 0) - 1, 0, this.elements().length - 1));
 				break;
 			case 'ArrowRight':
 				if(orientation !== "horizontal") break;
 				event.preventDefault();
-				this.currentIndex.update(index => clampNumber((index ?? -1) + 1, 0, this.elements().length - 1));
+				this.currentIndex.update(index => clampNumber((index ?? 0) + 1, 0, this.elements().length - 1));
 				break;
 			case 'Enter':
 			case ' ':

--- a/libs/frakton-ng/table/src/core/fkt-table.component.scss
+++ b/libs/frakton-ng/table/src/core/fkt-table.component.scss
@@ -16,8 +16,8 @@ $border-radius: var(--fkt-table-border-radius, var(--fkt-space-sm));
 Background color for table container.
 @name --fkt-table-cell-background
 @reference --fkt-color-neutral-100
-@category Color
-@type size
+@category Colors
+@type color
 */
 $cell-background: var(--fkt-table-cell-background, var(--fkt-color-neutral-100));
 


### PR DESCRIPTION
## Summary
- Reworked the docs playground to make design token scopes more discoverable with chip-based anatomy highlighting and filtered token groups.
- Updated the code/source panel presentation to keep examples visible while reducing visual noise and improving code inspection.
- Tightened supporting docs infrastructure, including story loading, TOC behavior, arg types, and token metadata rendering.
- Refined table examples and related docs stories to match the new anatomy-aware styling workflow.