### PR TITLE
[codex] Improve autocomplete customization and token controls

### DIFF
--- a/apps/docs/public/llms-full.md
+++ b/apps/docs/public/llms-full.md
@@ -7815,8 +7815,9 @@ the component.
 - type: story
 - component: AutocompleteCustomContentExampleComponent
 
-Custom item, group, header, and footer templates. Template contexts expose the normalized option
-and selection state, so custom UI remains type-safe while the form value stays primitive.
+Custom item, group, header, footer, chip, and empty-state templates. Template contexts expose
+normalized options and search state, so custom UI remains type-safe while the form value stays
+primitive. Chip templates preserve the built-in removal behavior and accessibility contract.
 
 Example component: `AutocompleteCustomContentExampleComponent`
 
@@ -7829,13 +7830,16 @@ import {
     FktAutocompleteFooterDirective,
     FktAutocompleteGroupDirective,
     FktAutocompleteHeaderDirective,
-    FktAutocompleteItemDirective
+    FktAutocompleteItemDirective,
+    FktAutocompleteChipDirective,
+    FktAutocompleteEmptyDirective,
 } from 'frakton-ng/autocomplete';
 import { FktButtonComponent } from 'frakton-ng/button';
 import { USERS } from '../autocomplete-demo-data';
 import { FktAvatarComponent } from 'frakton-ng/avatar';
 import { FktTagComponent } from 'frakton-ng/tag';
 import { CodeOutputComponent } from '@/components/code-output/code-output.component';
+import { FktIconComponent } from 'frakton-ng/icon';
 
 @Component({
     selector: 'app-autocomplete-custom-content-example',
@@ -7845,18 +7849,23 @@ import { CodeOutputComponent } from '@/components/code-output/code-output.compon
         FktAutocompleteGroupDirective,
         FktAutocompleteItemDirective,
         FktAutocompleteFooterDirective,
+        FktAutocompleteChipDirective,
+        FktAutocompleteEmptyDirective,
         FktButtonComponent,
         ReactiveFormsModule,
         FktAvatarComponent,
         FktTagComponent,
         CodeOutputComponent,
+        FktIconComponent,
     ],
     templateUrl: './autocomplete-custom-content-example.component.html',
     styleUrl: './autocomplete-custom-content-example.component.scss',
 })
 export class AutocompleteCustomContentExampleComponent {
     protected readonly users = USERS;
-    protected readonly member = new FormControl<string | null>(null);
+    protected readonly member = new FormControl<(string | number)[]>([
+        'usr-1001',
+    ]);
     protected readonly value = toSignal(this.member.valueChanges, {
         initialValue: this.member.value,
     });
@@ -7920,6 +7929,18 @@ export class AutocompleteCustomContentExampleComponent {
             theme="stroked"
             shape="rect"
         />
+    </div>
+
+    <div *fktAutocompleteChip="let item" class="custom-chip">
+        <fkt-avatar randomBackground size="xs" [initials]="item.label"/>
+        <span>{{ item.label }}</span>
+        <fkt-icon name="x-circle"/>
+    </div>
+
+    <div *fktAutocompleteEmpty="let state" class="empty-state">
+        <fkt-icon name="magnifying-glass"/>
+        <strong>No teammates found</strong>
+        <span>{{ state.label }}</span>
     </div>
 </fkt-autocomplete>
 ```
@@ -8009,6 +8030,35 @@ export class AutocompleteCustomContentExampleComponent {
     justify-content: space-between;
     padding: var(--fkt-space-xs);
     padding-bottom: 0;
+}
+
+.custom-chip {
+    align-items: center;
+    display: flex;
+    gap: var(--fkt-space-3xs);
+}
+
+.empty-state {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: var(--fkt-space-3xs);
+    padding: var(--fkt-space-md);
+    text-align: center;
+
+    fkt-icon {
+        color: var(--fkt-color-neutral-600);
+        font-size: var(--fkt-font-size-xl);
+    }
+
+    strong {
+        font-size: var(--fkt-font-size-sm);
+    }
+
+    span {
+        color: var(--fkt-color-neutral-700);
+        font-size: var(--fkt-font-size-xs);
+    }
 }
 
 pre {
@@ -8668,7 +8718,7 @@ Example component: `AutocompleteSignalFormsExampleComponent`
 
 ```ts title="autocomplete-signal-forms-example.component.ts"
 import { Component, signal } from '@angular/core';
-import { disabled, FormField, form, required } from '@angular/forms/signals';
+import { disabled, form, FormField, required } from '@angular/forms/signals';
 import { FktAutocompleteComponent } from 'frakton-ng/autocomplete';
 import { FktButtonComponent } from 'frakton-ng/button';
 import { COUNTRIES } from '../autocomplete-demo-data';
@@ -9261,9 +9311,17 @@ The overlay accepts projected templates for advanced rendering:
 - `fktAutocompleteGroup`
 - `fktAutocompleteItem`
 - `fktAutocompleteFooter`
+- `fktAutocompleteChip`
+- `fktAutocompleteEmpty`
 
 Templates customize rendering only. Keyboard navigation, active descendant, selection, form value,
 and overlay behavior remain managed by the component.
+
+`fktAutocompleteChip` receives the normalized selected option. It replaces the chip content while
+the autocomplete keeps the removable button, disabled state, focus handling, and accessible label.
+
+`fktAutocompleteEmpty` receives an empty-state object containing `label`, `query`, `minSearch`, and
+`reason`. The reason is `min-search`, `query-no-results`, or `no-results`.
 
 ## Performance Directives
 

--- a/apps/docs/public/llms/autocomplete.md
+++ b/apps/docs/public/llms/autocomplete.md
@@ -522,8 +522,9 @@ the component.
 - type: story
 - component: AutocompleteCustomContentExampleComponent
 
-Custom item, group, header, and footer templates. Template contexts expose the normalized option
-and selection state, so custom UI remains type-safe while the form value stays primitive.
+Custom item, group, header, footer, chip, and empty-state templates. Template contexts expose
+normalized options and search state, so custom UI remains type-safe while the form value stays
+primitive. Chip templates preserve the built-in removal behavior and accessibility contract.
 
 Example component: `AutocompleteCustomContentExampleComponent`
 
@@ -536,13 +537,16 @@ import {
     FktAutocompleteFooterDirective,
     FktAutocompleteGroupDirective,
     FktAutocompleteHeaderDirective,
-    FktAutocompleteItemDirective
+    FktAutocompleteItemDirective,
+    FktAutocompleteChipDirective,
+    FktAutocompleteEmptyDirective,
 } from 'frakton-ng/autocomplete';
 import { FktButtonComponent } from 'frakton-ng/button';
 import { USERS } from '../autocomplete-demo-data';
 import { FktAvatarComponent } from 'frakton-ng/avatar';
 import { FktTagComponent } from 'frakton-ng/tag';
 import { CodeOutputComponent } from '@/components/code-output/code-output.component';
+import { FktIconComponent } from 'frakton-ng/icon';
 
 @Component({
     selector: 'app-autocomplete-custom-content-example',
@@ -552,18 +556,23 @@ import { CodeOutputComponent } from '@/components/code-output/code-output.compon
         FktAutocompleteGroupDirective,
         FktAutocompleteItemDirective,
         FktAutocompleteFooterDirective,
+        FktAutocompleteChipDirective,
+        FktAutocompleteEmptyDirective,
         FktButtonComponent,
         ReactiveFormsModule,
         FktAvatarComponent,
         FktTagComponent,
         CodeOutputComponent,
+        FktIconComponent,
     ],
     templateUrl: './autocomplete-custom-content-example.component.html',
     styleUrl: './autocomplete-custom-content-example.component.scss',
 })
 export class AutocompleteCustomContentExampleComponent {
     protected readonly users = USERS;
-    protected readonly member = new FormControl<string | null>(null);
+    protected readonly member = new FormControl<(string | number)[]>([
+        'usr-1001',
+    ]);
     protected readonly value = toSignal(this.member.valueChanges, {
         initialValue: this.member.value,
     });
@@ -627,6 +636,18 @@ export class AutocompleteCustomContentExampleComponent {
             theme="stroked"
             shape="rect"
         />
+    </div>
+
+    <div *fktAutocompleteChip="let item" class="custom-chip">
+        <fkt-avatar randomBackground size="xs" [initials]="item.label"/>
+        <span>{{ item.label }}</span>
+        <fkt-icon name="x-circle"/>
+    </div>
+
+    <div *fktAutocompleteEmpty="let state" class="empty-state">
+        <fkt-icon name="magnifying-glass"/>
+        <strong>No teammates found</strong>
+        <span>{{ state.label }}</span>
     </div>
 </fkt-autocomplete>
 ```
@@ -716,6 +737,35 @@ export class AutocompleteCustomContentExampleComponent {
     justify-content: space-between;
     padding: var(--fkt-space-xs);
     padding-bottom: 0;
+}
+
+.custom-chip {
+    align-items: center;
+    display: flex;
+    gap: var(--fkt-space-3xs);
+}
+
+.empty-state {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: var(--fkt-space-3xs);
+    padding: var(--fkt-space-md);
+    text-align: center;
+
+    fkt-icon {
+        color: var(--fkt-color-neutral-600);
+        font-size: var(--fkt-font-size-xl);
+    }
+
+    strong {
+        font-size: var(--fkt-font-size-sm);
+    }
+
+    span {
+        color: var(--fkt-color-neutral-700);
+        font-size: var(--fkt-font-size-xs);
+    }
 }
 
 pre {
@@ -1375,7 +1425,7 @@ Example component: `AutocompleteSignalFormsExampleComponent`
 
 ```ts title="autocomplete-signal-forms-example.component.ts"
 import { Component, signal } from '@angular/core';
-import { disabled, FormField, form, required } from '@angular/forms/signals';
+import { disabled, form, FormField, required } from '@angular/forms/signals';
 import { FktAutocompleteComponent } from 'frakton-ng/autocomplete';
 import { FktButtonComponent } from 'frakton-ng/button';
 import { COUNTRIES } from '../autocomplete-demo-data';
@@ -1968,9 +2018,17 @@ The overlay accepts projected templates for advanced rendering:
 - `fktAutocompleteGroup`
 - `fktAutocompleteItem`
 - `fktAutocompleteFooter`
+- `fktAutocompleteChip`
+- `fktAutocompleteEmpty`
 
 Templates customize rendering only. Keyboard navigation, active descendant, selection, form value,
 and overlay behavior remain managed by the component.
+
+`fktAutocompleteChip` receives the normalized selected option. It replaces the chip content while
+the autocomplete keeps the removable button, disabled state, focus handling, and accessible label.
+
+`fktAutocompleteEmpty` receives an empty-state object containing `label`, `query`, `minSearch`, and
+`reason`. The reason is `min-search`, `query-no-results`, or `no-results`.
 
 ## Performance Directives
 

--- a/apps/docs/public/sitemap.xml
+++ b/apps/docs/public/sitemap.xml
@@ -22,7 +22,7 @@
         <loc>https://fraktonng.com/docs/autocomplete</loc>
         <priority>0.9</priority>
         <changefreq>weekly</changefreq>
-        <lastmod>2026-06-20T22:47:54.384Z</lastmod>
+        <lastmod>2026-06-21T08:54:56.947Z</lastmod>
     </url>
     <url>
         <loc>https://fraktonng.com/docs/avatar</loc>
@@ -94,7 +94,7 @@
         <loc>https://fraktonng.com/docs/field</loc>
         <priority>0.9</priority>
         <changefreq>weekly</changefreq>
-        <lastmod>2026-06-20T22:47:56.247Z</lastmod>
+        <lastmod>2026-06-20T23:14:30.437Z</lastmod>
     </url>
     <url>
         <loc>https://fraktonng.com/docs/focus-trap</loc>
@@ -112,7 +112,7 @@
         <loc>https://fraktonng.com/docs/input</loc>
         <priority>0.9</priority>
         <changefreq>weekly</changefreq>
-        <lastmod>2026-06-20T22:48:01.837Z</lastmod>
+        <lastmod>2026-06-20T23:14:30.450Z</lastmod>
     </url>
     <url>
         <loc>https://fraktonng.com/docs/navigator</loc>
@@ -190,7 +190,7 @@
         <loc>https://fraktonng.com/docs/textarea</loc>
         <priority>0.9</priority>
         <changefreq>weekly</changefreq>
-        <lastmod>2026-06-20T22:48:03.800Z</lastmod>
+        <lastmod>2026-06-20T23:14:30.480Z</lastmod>
     </url>
     <url>
         <loc>https://fraktonng.com/docs/toggle</loc>

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/color/design-token-color-control.component.html
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/color/design-token-color-control.component.html
@@ -1,0 +1,5 @@
+<fkt-color-picker
+    [(value)]="token().control"
+    [showCopyButton]="false"
+    label="Pick a color"
+/>

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/color/design-token-color-control.component.ts
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/color/design-token-color-control.component.ts
@@ -1,0 +1,12 @@
+import { Component, input } from '@angular/core';
+import { DesignTokenItem } from '@/models/design-token-item';
+import { FktColorPickerComponent } from 'frakton-ng/color-picker';
+
+@Component({
+    selector: 'app-design-token-color-control',
+    imports: [FktColorPickerComponent],
+    templateUrl: './design-token-color-control.component.html',
+})
+export class DesignTokenColorControlComponent {
+    readonly token = input.required<DesignTokenItem>();
+}

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/numeric-token-control.scss
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/numeric-token-control.scss
@@ -1,0 +1,21 @@
+.numeric-control {
+    display: flex;
+    flex-direction: column;
+    gap: .2rem;
+    pointer-events: auto;
+    width: fit-content;
+
+    fkt-icon {
+        background-color: var(--fkt-controls-table-numeric-control-bg);
+        color: var(--fkt-controls-table-numeric-control-color);
+        cursor: pointer;
+        font-size: var(--fkt-font-size-xs);
+        font-weight: var(--fkt-font-semibold);
+        padding: 0 .2rem;
+        transition: var(--fkt-transition-base);
+
+        &:hover {
+            background-color: var(--fkt-controls-table-numeric-control-hover-bg);
+        }
+    }
+}

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/numeric-token-control.ts
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/numeric-token-control.ts
@@ -1,0 +1,53 @@
+import { WritableSignal } from '@angular/core';
+
+export const getUpdatedNumericTokenValue = (
+    event: KeyboardEvent | MouseEvent,
+    value: string,
+    operation: 'increase' | 'decrease'
+) => {
+    event.preventDefault();
+
+    const numberPart = value.match(/-?\d*\.?\d+/)?.[0];
+
+    if (!numberPart) return value;
+
+    let factor = value.includes('rem') ? 0.25 : 1;
+
+    if (event instanceof KeyboardEvent && event.shiftKey) factor = 10;
+    if (event instanceof KeyboardEvent && event.ctrlKey) factor = 0.1;
+
+    let updatedNumber =
+        Number(numberPart) + (operation === 'increase' ? factor : -factor);
+
+    if (updatedNumber.toString().length > updatedNumber.toFixed(2).length) {
+        updatedNumber = Number(updatedNumber.toFixed(2));
+    }
+
+    return value.replace(numberPart, updatedNumber.toString());
+};
+
+export const updateNumericToken = (
+    event: KeyboardEvent | MouseEvent,
+    control: WritableSignal<string>,
+    operation: 'increase' | 'decrease'
+) => {
+    control.set(getUpdatedNumericTokenValue(event, control(), operation));
+};
+
+export const handleNumericTokenKeydown = (
+    event: KeyboardEvent,
+    control: WritableSignal<string>
+) => {
+    const operationByKey: Partial<
+        Record<string, 'increase' | 'decrease'>
+    > = {
+        ArrowUp: 'increase',
+        ArrowDown: 'decrease',
+        '+': 'increase',
+        '-': 'decrease',
+    };
+
+    const operation = operationByKey[event.key];
+
+    if (operation) updateNumericToken(event, control, operation);
+};

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/opacity/design-token-opacity-control.component.html
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/opacity/design-token-opacity-control.component.html
@@ -1,0 +1,11 @@
+<fkt-input
+    [label]="token().name"
+    hideLabel
+    type="number"
+    [minNumber]="0"
+    [maxNumber]="1"
+    [step]="0.1"
+    [maxDecimals]="2"
+    placeholder="Enter the opacity"
+    [(value)]="token().control"
+/>

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/opacity/design-token-opacity-control.component.ts
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/opacity/design-token-opacity-control.component.ts
@@ -1,0 +1,12 @@
+import { Component, input } from '@angular/core';
+import { DesignTokenItem } from '@/models/design-token-item';
+import { FktInputOldComponent } from 'frakton-ng/input-old';
+
+@Component({
+    selector: 'app-design-token-opacity-control',
+    imports: [FktInputOldComponent],
+    templateUrl: './design-token-opacity-control.component.html',
+})
+export class DesignTokenOpacityControlComponent {
+    readonly token = input.required<DesignTokenItem>();
+}

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/shadow/design-token-shadow-control.component.html
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/shadow/design-token-shadow-control.component.html
@@ -1,0 +1,6 @@
+<fkt-input
+    [label]="token().name"
+    hideLabel
+    placeholder="Enter a shadow value"
+    [(value)]="token().control"
+/>

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/shadow/design-token-shadow-control.component.ts
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/shadow/design-token-shadow-control.component.ts
@@ -1,0 +1,12 @@
+import { Component, input } from '@angular/core';
+import { DesignTokenItem } from '@/models/design-token-item';
+import { FktInputOldComponent } from 'frakton-ng/input-old';
+
+@Component({
+    selector: 'app-design-token-shadow-control',
+    imports: [FktInputOldComponent],
+    templateUrl: './design-token-shadow-control.component.html',
+})
+export class DesignTokenShadowControlComponent {
+    readonly token = input.required<DesignTokenItem>();
+}

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/size/design-token-size-control.component.html
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/size/design-token-size-control.component.html
@@ -1,0 +1,18 @@
+<fkt-input
+    [label]="token().name"
+    hideLabel
+    (inputKeyDown)="onKeydown($event, token().control)"
+    placeholder="Enter the size"
+    [(value)]="token().control"
+>
+    <div *fktFormControlSuffix class="numeric-control">
+        <fkt-icon
+            (mousedown)="update($any($event), token().control, 'increase')"
+            name="chevron-up"
+        />
+        <fkt-icon
+            (mousedown)="update($any($event), token().control, 'decrease')"
+            name="chevron-down"
+        />
+    </div>
+</fkt-input>

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/size/design-token-size-control.component.ts
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/size/design-token-size-control.component.ts
@@ -1,0 +1,26 @@
+import { Component, input } from '@angular/core';
+import { DesignTokenItem } from '@/models/design-token-item';
+import { FktInputOldComponent } from 'frakton-ng/input-old';
+import { FormControlSuffixDirective } from 'frakton-ng/forms';
+import { FktIconComponent } from 'frakton-ng/icon';
+import {
+    handleNumericTokenKeydown,
+    updateNumericToken,
+} from '../numeric-token-control';
+
+@Component({
+    selector: 'app-design-token-size-control',
+    imports: [
+        FktInputOldComponent,
+        FormControlSuffixDirective,
+        FktIconComponent,
+    ],
+    templateUrl: './design-token-size-control.component.html',
+    styleUrl: '../numeric-token-control.scss',
+})
+export class DesignTokenSizeControlComponent {
+    readonly token = input.required<DesignTokenItem>();
+
+    protected readonly onKeydown = handleNumericTokenKeydown;
+    protected readonly update = updateNumericToken;
+}

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/spacing/design-token-spacing-control.component.html
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/spacing/design-token-spacing-control.component.html
@@ -1,0 +1,37 @@
+<div class="preview">
+    <fkt-button
+        [ariaLabel]="expanded() ? 'Collapse spacing editor' : 'Expand spacing editor'"
+        [fktTooltip]="expanded() ? 'Collapse' : 'Edit each side'"
+        [icon]="expanded() ? 'chevron-up' : 'chevron-down'"
+        theme="basic"
+        (click)="expanded.set(!expanded())"
+    />
+    <span [title]="token().control()">{{ token().control() }}</span>
+</div>
+
+<div class="sides" [class.expanded]="expanded()">
+    <fkt-input
+        label="Top"
+        [value]="sides().top"
+        (inputKeyDown)="onKeydown($event, 'top', sides().top)"
+        (valueChange)="updateSide('top', $event)"
+    />
+    <fkt-input
+        label="Right"
+        [value]="sides().right"
+        (inputKeyDown)="onKeydown($event, 'right', sides().right)"
+        (valueChange)="updateSide('right', $event)"
+    />
+    <fkt-input
+        label="Bottom"
+        [value]="sides().bottom"
+        (inputKeyDown)="onKeydown($event, 'bottom', sides().bottom)"
+        (valueChange)="updateSide('bottom', $event)"
+    />
+    <fkt-input
+        label="Left"
+        [value]="sides().left"
+        (inputKeyDown)="onKeydown($event, 'left', sides().left)"
+        (valueChange)="updateSide('left', $event)"
+    />
+</div>

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/spacing/design-token-spacing-control.component.scss
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/spacing/design-token-spacing-control.component.scss
@@ -1,0 +1,41 @@
+:host {
+    display: grid;
+    gap: var(--fkt-space-xs);
+
+    --fkt-button-icon-font-size: var(--fkt-font-size-xs);
+    --fkt-button-padding-horizontal: var(--fkt-space-3xs);
+    --fkt-button-padding-vertical: var(--fkt-space-3xs);
+}
+
+.preview {
+    align-items: center;
+    border: 1px solid var(--fkt-color-neutral-400);
+    border-radius: var(--fkt-radius-md);
+    display: flex;
+    gap: var(--fkt-space-3xs);
+    padding: var(--fkt-space-2xs) var(--fkt-space-xs);
+
+    span {
+        color: var(--fkt-color-neutral-800);
+        font-family: monospace;
+        font-size: var(--fkt-font-size-sm);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+}
+
+.sides {
+    display: flex;
+    flex-direction: column;
+    gap: var(--fkt-space-sm);
+    transition: var(--fkt-transition-base);
+    max-height: 0;
+    overflow: hidden;
+    box-sizing: border-box;
+
+    &.expanded {
+        padding: var(--fkt-space-xs);
+        max-height: 200px;
+    }
+}

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/spacing/design-token-spacing-control.component.ts
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/spacing/design-token-spacing-control.component.ts
@@ -1,0 +1,100 @@
+import { Component, input, linkedSignal, signal } from '@angular/core';
+import { DesignTokenItem } from '@/models/design-token-item';
+import { FktButtonComponent } from 'frakton-ng/button';
+import { FktInputOldComponent } from 'frakton-ng/input-old';
+import { FktTooltipDirective } from 'frakton-ng/tooltip';
+import { getUpdatedNumericTokenValue } from '../numeric-token-control';
+
+type SpacingSide = 'top' | 'right' | 'bottom' | 'left';
+
+interface SpacingSides {
+    top: string;
+    right: string;
+    bottom: string;
+    left: string;
+}
+
+const parseSpacing = (value: string): SpacingSides => {
+    const parts = value.trim().split(/\s+/).filter(Boolean);
+    const [first = '', second = first, third = first, fourth = second] = parts;
+
+    if (parts.length === 2) {
+        return {
+            top: first,
+            right: second,
+            bottom: first,
+            left: second,
+        };
+    }
+
+    if (parts.length === 3) {
+        return {
+            top: first,
+            right: second,
+            bottom: third,
+            left: second,
+        };
+    }
+
+    return {
+        top: first,
+        right: second,
+        bottom: third,
+        left: fourth,
+    };
+};
+
+@Component({
+    selector: 'app-design-token-spacing-control',
+    imports: [
+        FktButtonComponent,
+        FktInputOldComponent,
+        FktTooltipDirective,
+    ],
+    templateUrl: './design-token-spacing-control.component.html',
+    styleUrl: './design-token-spacing-control.component.scss',
+})
+export class DesignTokenSpacingControlComponent {
+    readonly token = input.required<DesignTokenItem>();
+
+    protected readonly expanded = signal(false);
+    protected readonly sides = linkedSignal(() =>
+        parseSpacing(this.token().control())
+    );
+
+    protected updateSide(side: SpacingSide, value: string | null) {
+        const sides = {
+            ...this.sides(),
+            [side]: value || '0',
+        };
+
+        this.sides.set(sides);
+        this.token().control.set(
+            [sides.top, sides.right, sides.bottom, sides.left].join(' ')
+        );
+    }
+
+    protected onKeydown(
+        event: KeyboardEvent,
+        side: SpacingSide,
+        value: string
+    ) {
+        const operationByKey: Partial<
+            Record<string, 'increase' | 'decrease'>
+        > = {
+            ArrowUp: 'increase',
+            ArrowDown: 'decrease',
+            '+': 'increase',
+            '-': 'decrease',
+        };
+
+        const operation = operationByKey[event.key];
+
+        if (!operation) return;
+
+        this.updateSide(
+            side,
+            getUpdatedNumericTokenValue(event, value, operation)
+        );
+    }
+}

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/weight/design-token-weight-control.component.html
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/weight/design-token-weight-control.component.html
@@ -1,0 +1,18 @@
+<fkt-input
+    [label]="token().name"
+    hideLabel
+    (inputKeyDown)="onKeydown($event, token().control)"
+    placeholder="Enter the weight"
+    [(value)]="token().control"
+>
+    <div *fktFormControlSuffix class="numeric-control">
+        <fkt-icon
+            (mousedown)="update($any($event), token().control, 'increase')"
+            name="chevron-up"
+        />
+        <fkt-icon
+            (mousedown)="update($any($event), token().control, 'decrease')"
+            name="chevron-down"
+        />
+    </div>
+</fkt-input>

--- a/apps/docs/src/app/components/playground/components/design-tokens/controls/weight/design-token-weight-control.component.ts
+++ b/apps/docs/src/app/components/playground/components/design-tokens/controls/weight/design-token-weight-control.component.ts
@@ -1,0 +1,26 @@
+import { Component, input } from '@angular/core';
+import { DesignTokenItem } from '@/models/design-token-item';
+import { FktInputOldComponent } from 'frakton-ng/input-old';
+import { FormControlSuffixDirective } from 'frakton-ng/forms';
+import { FktIconComponent } from 'frakton-ng/icon';
+import {
+    handleNumericTokenKeydown,
+    updateNumericToken,
+} from '../numeric-token-control';
+
+@Component({
+    selector: 'app-design-token-weight-control',
+    imports: [
+        FktInputOldComponent,
+        FormControlSuffixDirective,
+        FktIconComponent,
+    ],
+    templateUrl: './design-token-weight-control.component.html',
+    styleUrl: '../numeric-token-control.scss',
+})
+export class DesignTokenWeightControlComponent {
+    readonly token = input.required<DesignTokenItem>();
+
+    protected readonly onKeydown = handleNumericTokenKeydown;
+    protected readonly update = updateNumericToken;
+}

--- a/apps/docs/src/app/components/playground/components/design-tokens/info/design-token-info.component.html
+++ b/apps/docs/src/app/components/playground/components/design-tokens/info/design-token-info.component.html
@@ -7,7 +7,7 @@
         variant="opaque"
         [color]="categoryIcon().color"
     >
-        <div tag-content>
+        <div tag-content [attr.data-color]="categoryIcon().color">
             <fkt-icon [name]="categoryIcon().icon"/>
             {{ token().category }}
         </div>

--- a/apps/docs/src/app/components/playground/components/design-tokens/info/design-token-info.component.scss
+++ b/apps/docs/src/app/components/playground/components/design-tokens/info/design-token-info.component.scss
@@ -27,8 +27,68 @@
 
 [tag-content] {
     display: flex;
-    gap: var(--fkt-space-xs);
+    gap: var(--fkt-space-2xs);
     align-items: center;
+
+    &[data-color="info"] {
+        color: contrast-color(var(--fkt-color-info));
+
+        fkt-icon {
+            color: contrast-color(var(--fkt-color-info));
+        }
+    }
+
+    &[data-color="warning"] {
+        color: contrast-color(var(--fkt-color-warning));
+
+        fkt-icon {
+            color: contrast-color(var(--fkt-color-warning));
+        }
+    }
+
+    &[data-color="accent"] {
+        color: contrast-color(var(--fkt-color-accent));
+
+        fkt-icon {
+            color: contrast-color(var(--fkt-color-accent));
+        }
+    }
+
+    &[data-color="success"] {
+        color: contrast-color(var(--fkt-color-success));
+
+        fkt-icon {
+            color: contrast-color(var(--fkt-color-success));
+        }
+    }
+
+    &[data-color="danger"] {
+        color: contrast-color(var(--fkt-color-danger));
+
+        fkt-icon {
+            color: contrast-color(var(--fkt-color-danger));
+        }
+    }
+}
+
+fkt-tag[color="info"] [tag-content] {
+    color: contrast-color(var(--fkt-color-info));
+}
+
+fkt-tag[color="warning"] [tag-content] {
+    color: contrast-color(var(--fkt-color-warning));
+}
+
+fkt-tag[color="accent"] [tag-content] {
+    color: contrast-color(var(--fkt-color-accent));
+}
+
+fkt-tag[color="success"] [tag-content] {
+    color: contrast-color(var(--fkt-color-success));
+}
+
+fkt-tag[color="danger"] [tag-content] {
+    color: contrast-color(var(--fkt-color-danger));
 }
 
 .row {

--- a/apps/docs/src/app/components/playground/components/design-tokens/item/story-design-tokens-item.component.html
+++ b/apps/docs/src/app/components/playground/components/design-tokens/item/story-design-tokens-item.component.html
@@ -36,70 +36,22 @@
 <div class="controls">
     @switch (designToken().type) {
         @case ("size") {
-            <fkt-input
-                [label]="designToken().name"
-                hideLabel
-                (inputKeyDown)="onKeyDown($event, designToken().control)"
-                placeholder="Enter the size"
-                [(value)]="designToken().control"
-            >
-                <div *fktFormControlSuffix class="numeric-control">
-                    <fkt-icon
-                        (mousedown)="increaseNumber($any($event), designToken().control)"
-                        name="chevron-up"/>
-                    <fkt-icon
-                        (mousedown)="decreaseNumber($any($event), designToken().control)"
-                        name="chevron-down"/>
-                </div>
-            </fkt-input>
+            <app-design-token-size-control [token]="designToken()"/>
+        }
+        @case ("spacing") {
+            <app-design-token-spacing-control [token]="designToken()"/>
         }
         @case ("weight") {
-            <fkt-input
-                [label]="designToken().name"
-                hideLabel
-                (inputKeyDown)="onKeyDown($event, designToken().control)"
-                placeholder="Enter the weight"
-                [(value)]="designToken().control"
-            >
-                <div *fktFormControlSuffix class="numeric-control">
-                    <fkt-icon
-                        (mousedown)="increaseNumber($any($event), designToken().control)"
-                        name="chevron-up"/>
-                    <fkt-icon
-                        (mousedown)="decreaseNumber($any($event), designToken().control)"
-                        name="chevron-down"/>
-                </div>
-            </fkt-input>
+            <app-design-token-weight-control [token]="designToken()"/>
         }
         @case ("opacity") {
-            <fkt-input
-                [label]="designToken().name"
-                hideLabel
-                type="number"
-                [minNumber]="0"
-                [maxNumber]="1"
-                [step]="0.1"
-                [maxDecimals]="2"
-                placeholder="Enter the opacity"
-                [(value)]="designToken().control"
-            >
-            </fkt-input>
+            <app-design-token-opacity-control [token]="designToken()"/>
         }
         @case ("shadow") {
-            <fkt-input
-                [label]="designToken().name"
-                hideLabel
-                placeholder="Enter a shadow value"
-                [(value)]="designToken().control"
-            >
-            </fkt-input>
+            <app-design-token-shadow-control [token]="designToken()"/>
         }
         @case ("color") {
-            <fkt-color-picker
-                [(value)]="designToken().control"
-                [showCopyButton]="false"
-                label="Pick a color"
-            />
+            <app-design-token-color-control [token]="designToken()"/>
         }
     }
 </div>

--- a/apps/docs/src/app/components/playground/components/design-tokens/item/story-design-tokens-item.component.scss
+++ b/apps/docs/src/app/components/playground/components/design-tokens/item/story-design-tokens-item.component.scss
@@ -47,28 +47,6 @@
     width: 100%;
 }
 
-.numeric-control {
-    width: fit-content;
-    display: flex;
-    flex-direction: column;
-    pointer-events: auto;
-    gap: .2rem;
-
-    fkt-icon {
-        font-size: var(--fkt-font-size-xs);
-        background-color: var(--fkt-controls-table-numeric-control-bg);
-        transition: var(--fkt-transition-base);
-        cursor: pointer;
-        color: var(--fkt-controls-table-numeric-control-color);
-        padding: 0 .2rem;
-        font-weight: var(--fkt-font-semibold);
-
-        &:hover {
-            background-color: var(--fkt-controls-table-numeric-control-hover-bg);
-        }
-    }
-}
-
 :host td.actions {
     padding: 0;
 

--- a/apps/docs/src/app/components/playground/components/design-tokens/item/story-design-tokens-item.component.ts
+++ b/apps/docs/src/app/components/playground/components/design-tokens/item/story-design-tokens-item.component.ts
@@ -1,29 +1,47 @@
-import { Component, computed, inject, input, Pipe, PipeTransform, signal, WritableSignal } from '@angular/core';
+import { Component, computed, inject, input, signal } from '@angular/core';
 import { DesignTokenItem } from '@/models/design-token-item';
 import { FktButtonComponent } from 'frakton-ng/button';
-import { FktInputOldComponent } from 'frakton-ng/input-old';
 import { FktTooltipDirective } from 'frakton-ng/tooltip';
-import { FktColorPickerComponent } from 'frakton-ng/color-picker';
 import { FktIconComponent, FktIconName } from 'frakton-ng/icon';
-import { FormControlSuffixDirective } from 'frakton-ng/forms';
 import { wait } from 'frakton-ng/internal/utils';
 import { FktOverlayRef, FktOverlayService } from 'frakton-ng/overlay';
 import { HumanizeDesignTokenPipe } from '@/pipes/humanize-design-token.pipe';
 import {
     DesignTokenInfoComponent
 } from '@/components/playground/components/design-tokens/info/design-token-info.component';
+import {
+    DesignTokenSizeControlComponent
+} from '../controls/size/design-token-size-control.component';
+import {
+    DesignTokenWeightControlComponent
+} from '../controls/weight/design-token-weight-control.component';
+import {
+    DesignTokenOpacityControlComponent
+} from '../controls/opacity/design-token-opacity-control.component';
+import {
+    DesignTokenShadowControlComponent
+} from '../controls/shadow/design-token-shadow-control.component';
+import {
+    DesignTokenColorControlComponent
+} from '../controls/color/design-token-color-control.component';
+import {
+    DesignTokenSpacingControlComponent
+} from '../controls/spacing/design-token-spacing-control.component';
 
 
 @Component({
     selector: 'app-story-design-tokens-item',
     imports: [
         FktButtonComponent,
-        FktInputOldComponent,
         FktTooltipDirective,
-        FktColorPickerComponent,
         FktIconComponent,
-        FormControlSuffixDirective,
         HumanizeDesignTokenPipe,
+        DesignTokenSizeControlComponent,
+        DesignTokenWeightControlComponent,
+        DesignTokenOpacityControlComponent,
+        DesignTokenShadowControlComponent,
+        DesignTokenColorControlComponent,
+        DesignTokenSpacingControlComponent,
     ],
     templateUrl: './story-design-tokens-item.component.html',
     styleUrl: './story-design-tokens-item.component.scss',
@@ -72,63 +90,6 @@ export class StoryDesignTokensItemComponent {
         const token = this.designToken();
 
         token.control.set(token.defaultValue);
-    }
-
-    protected onKeyDown(event: KeyboardEvent, control: WritableSignal<string>) {
-        const keysMap: Record<
-            string,
-            (event: KeyboardEvent, control: WritableSignal<string>) => void
-        > = {
-            ArrowUp: this.increaseNumber,
-            ArrowDown: this.decreaseNumber,
-            '+': this.increaseNumber,
-            '-': this.decreaseNumber,
-        };
-
-        keysMap[event.key]?.(event, control);
-    }
-
-    protected increaseNumber = (
-        event: KeyboardEvent,
-        control: WritableSignal<string>
-    ) => {
-        this.updateSpacingValue(event, control, 'increase');
-    };
-
-    protected decreaseNumber = (
-        event: KeyboardEvent,
-        control: WritableSignal<string>
-    ) => {
-        this.updateSpacingValue(event, control, 'decrease');
-    };
-
-    private updateSpacingValue(
-        event: KeyboardEvent,
-        control: WritableSignal<string>,
-        operation: 'increase' | 'decrease'
-    ) {
-        event.preventDefault();
-
-        const value = control();
-        const numberPart = value.match(/-?\d*\.?\d+/)?.[0];
-
-        if (!numberPart) return;
-
-        let factor = 1;
-
-        if (value.includes('rem')) factor = 0.25;
-
-        if (event.shiftKey) factor = 10;
-
-        if (event.ctrlKey) factor = 0.1;
-
-        let asNumber =
-            +numberPart + (operation === 'increase' ? factor : factor * -1);
-
-        if (asNumber.toString().length > asNumber.toFixed(2).length)
-            asNumber = +asNumber.toFixed(2);
-
-        control.set(value.replace(numberPart.toString(), asNumber.toString()));
     }
 
     protected openInfo(button: HTMLButtonElement) {

--- a/apps/docs/src/app/components/playground/components/design-tokens/story-design-tokens.component.scss
+++ b/apps/docs/src/app/components/playground/components/design-tokens/story-design-tokens.component.scss
@@ -64,9 +64,10 @@
     --anatomy-color: var(--fkt-color-danger);
 
     .range {
+        box-sizing: border-box;
         border: solid 1px var(--anatomy-color);
         background: rgb(from var(--anatomy-color) r g b / 0.1);
-        border-radius: 0 var(--fkt-radius-md) var(--fkt-radius-md) var(--fkt-radius-md);
+        border-radius: 0;
     }
 
     .label {

--- a/apps/docs/src/app/models/design-token-item.ts
+++ b/apps/docs/src/app/models/design-token-item.ts
@@ -10,7 +10,7 @@ export interface DesignTokenItem {
 		selector: string;
 	};
 	description: string;
-	type: 'size' | 'color' | 'shadow' | 'weight' | 'opacity';
+	type: 'size' | 'spacing' | 'color' | 'shadow' | 'weight' | 'opacity';
 	defaultValue: string;
 	control: WritableSignal<string>;
 }

--- a/apps/docs/src/app/models/design-token.ts
+++ b/apps/docs/src/app/models/design-token.ts
@@ -8,6 +8,6 @@ export interface DesignToken {
 		name: string;
 		selector: string;
 	};
-	type: 'size' | 'color';
+	type: 'size' | 'spacing' | 'color' | 'shadow' | 'weight' | 'opacity';
 	defaultValue: string;
 }

--- a/apps/docs/src/app/stories/autocomplete/examples/custom-content/autocomplete-custom-content-example.component.html
+++ b/apps/docs/src/app/stories/autocomplete/examples/custom-content/autocomplete-custom-content-example.component.html
@@ -55,4 +55,16 @@
             shape="rect"
         />
     </div>
+
+    <div *fktAutocompleteChip="let item" class="custom-chip">
+        <fkt-avatar randomBackground size="xs" [initials]="item.label"/>
+        <span>{{ item.label }}</span>
+        <fkt-icon name="x-circle"/>
+    </div>
+
+    <div *fktAutocompleteEmpty="let state" class="empty-state">
+        <fkt-icon name="magnifying-glass"/>
+        <strong>No teammates found</strong>
+        <span>{{ state.label }}</span>
+    </div>
 </fkt-autocomplete>

--- a/apps/docs/src/app/stories/autocomplete/examples/custom-content/autocomplete-custom-content-example.component.scss
+++ b/apps/docs/src/app/stories/autocomplete/examples/custom-content/autocomplete-custom-content-example.component.scss
@@ -84,6 +84,35 @@
     padding-bottom: 0;
 }
 
+.custom-chip {
+    align-items: center;
+    display: flex;
+    gap: var(--fkt-space-3xs);
+}
+
+.empty-state {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: var(--fkt-space-3xs);
+    padding: var(--fkt-space-md);
+    text-align: center;
+
+    fkt-icon {
+        color: var(--fkt-color-neutral-600);
+        font-size: var(--fkt-font-size-xl);
+    }
+
+    strong {
+        font-size: var(--fkt-font-size-sm);
+    }
+
+    span {
+        color: var(--fkt-color-neutral-700);
+        font-size: var(--fkt-font-size-xs);
+    }
+}
+
 pre {
     margin: 1rem 0 0;
 }

--- a/apps/docs/src/app/stories/autocomplete/examples/custom-content/autocomplete-custom-content-example.component.ts
+++ b/apps/docs/src/app/stories/autocomplete/examples/custom-content/autocomplete-custom-content-example.component.ts
@@ -6,13 +6,16 @@ import {
     FktAutocompleteFooterDirective,
     FktAutocompleteGroupDirective,
     FktAutocompleteHeaderDirective,
-    FktAutocompleteItemDirective
+    FktAutocompleteItemDirective,
+    FktAutocompleteChipDirective,
+    FktAutocompleteEmptyDirective,
 } from 'frakton-ng/autocomplete';
 import { FktButtonComponent } from 'frakton-ng/button';
 import { USERS } from '../autocomplete-demo-data';
 import { FktAvatarComponent } from 'frakton-ng/avatar';
 import { FktTagComponent } from 'frakton-ng/tag';
 import { CodeOutputComponent } from '@/components/code-output/code-output.component';
+import { FktIconComponent } from 'frakton-ng/icon';
 
 @Component({
     selector: 'app-autocomplete-custom-content-example',
@@ -22,18 +25,23 @@ import { CodeOutputComponent } from '@/components/code-output/code-output.compon
         FktAutocompleteGroupDirective,
         FktAutocompleteItemDirective,
         FktAutocompleteFooterDirective,
+        FktAutocompleteChipDirective,
+        FktAutocompleteEmptyDirective,
         FktButtonComponent,
         ReactiveFormsModule,
         FktAvatarComponent,
         FktTagComponent,
         CodeOutputComponent,
+        FktIconComponent,
     ],
     templateUrl: './autocomplete-custom-content-example.component.html',
     styleUrl: './autocomplete-custom-content-example.component.scss',
 })
 export class AutocompleteCustomContentExampleComponent {
     protected readonly users = USERS;
-    protected readonly member = new FormControl<string | null>(null);
+    protected readonly member = new FormControl<(string | number)[]>([
+        'usr-1001',
+    ]);
     protected readonly value = toSignal(this.member.valueChanges, {
         initialValue: this.member.value,
     });

--- a/apps/docs/src/app/stories/autocomplete/fkt-autocomplete-design-tokens.json
+++ b/apps/docs/src/app/stories/autocomplete/fkt-autocomplete-design-tokens.json
@@ -1,5 +1,256 @@
 [
   {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Vertical padding inside the input field (top and bottom spacing between border and content).",
+    "name": "--fkt-field-vertical-padding",
+    "reference": "--fkt-space-inset-3xs",
+    "category": "Spacing",
+    "type": "size",
+    "defaultValue": ".5rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Vertical padding inside the input field (top and bottom spacing between border and content).",
+    "name": "--fkt-field-vertical-padding-sm",
+    "reference": "--fkt-space-inset-4xs",
+    "category": "Spacing",
+    "type": "size",
+    "defaultValue": ".375rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Vertical padding inside the input field (top and bottom spacing between border and content).",
+    "name": "--fkt-field-vertical-padding-lg",
+    "reference": "--fkt-space-inset-2xs",
+    "category": "Spacing",
+    "type": "size",
+    "defaultValue": ".625rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Horizontal padding inside the input field (left and right spacing between border and content).",
+    "name": "--fkt-field-horizontal-padding",
+    "reference": "--fkt-space-inset-2xs",
+    "category": "Spacing",
+    "type": "size",
+    "defaultValue": ".625rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Horizontal padding inside the input field (left and right spacing between border and content).",
+    "name": "--fkt-field-horizontal-padding-sm",
+    "reference": "--fkt-space-inset-3xs",
+    "category": "Spacing",
+    "type": "size",
+    "defaultValue": ".5rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Horizontal padding inside the input field (left and right spacing between border and content).",
+    "name": "--fkt-field-horizontal-padding-lg",
+    "reference": "--fkt-space-inset-xs",
+    "category": "Spacing",
+    "type": "size",
+    "defaultValue": ".75rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Border color of the input in its normal (default) state.",
+    "name": "--fkt-field-border-color",
+    "reference": "--fkt-color-neutral-400",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#94a3b8",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Border color of the input when it gets focused",
+    "name": "--fkt-field-border-focus-color",
+    "reference": "--fkt-color-neutral-800",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#1e293b",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Color of the label in its normal (default) state.",
+    "name": "--fkt-field-label-color",
+    "reference": "--fkt-color-neutral-700",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#334155",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Color of the label when it gets focused",
+    "name": "--fkt-field-label-focus-color",
+    "reference": "--fkt-color-neutral-800",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#1e293b",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Border radius for input",
+    "name": "--fkt-field-border-radius",
+    "reference": "--fkt-radius-md",
+    "category": "Spacing",
+    "type": "size",
+    "defaultValue": ".375rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Font size for input text and placeholder.",
+    "name": "--fkt-field-font-size",
+    "reference": "--fkt-font-size-sm",
+    "category": "Typography",
+    "type": "size",
+    "defaultValue": "0.875rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Font size for input text and placeholder.",
+    "name": "--fkt-field-font-size-sm",
+    "reference": "--fkt-font-size-xs",
+    "category": "Typography",
+    "type": "size",
+    "defaultValue": "0.75rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Font size for input text and placeholder.",
+    "name": "--fkt-field-font-size-lg",
+    "reference": "--fkt-font-size-md",
+    "category": "Typography",
+    "type": "size",
+    "defaultValue": "1rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Field",
+      "selector": "fkt-autocomplete"
+    },
+    "description": "Color for text written into input",
+    "name": "--fkt-field-text-color",
+    "reference": "--fkt-color-neutral-900",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#0f172a",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Prefix",
+      "selector": "[fktFieldPrefix]"
+    },
+    "description": "Space between prefix and field element",
+    "name": "--fkt-field-prefix-gap",
+    "reference": "--fkt-space-xs",
+    "category": "Spacing",
+    "type": "size",
+    "defaultValue": ".5rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Prefix",
+      "selector": "[fktFieldPrefix]"
+    },
+    "description": "Text color for prefix when field is at invalid state",
+    "name": "--fkt-field-prefix-invalid-text",
+    "reference": "--fkt-color-danger",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#E7000BFF",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Suffix",
+      "selector": "[fktFieldSuffix]"
+    },
+    "description": "Space between suffix and field element",
+    "name": "--fkt-field-suffix-gap",
+    "reference": "--fkt-space-xs",
+    "category": "Spacing",
+    "type": "size",
+    "defaultValue": ".5rem",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Suffix",
+      "selector": "[fktFieldSuffix]"
+    },
+    "description": "Text color for suffix when field is at invalid state",
+    "name": "--fkt-field-suffix-invalid-text",
+    "reference": "--fkt-color-danger",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#E7000BFF",
+    "component": "Field"
+  },
+  {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
     "description": "Background color for the autocomplete options overlay.",
     "name": "--fkt-autocomplete-options-background-color",
     "reference": "--fkt-color-modal-background",
@@ -9,6 +260,10 @@
     "defaultValue": "#f1f5f9"
   },
   {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
     "description": "Text color for the autocomplete options overlay.",
     "name": "--fkt-autocomplete-options-text-color",
     "reference": "--fkt-color-neutral-950",
@@ -18,15 +273,23 @@
     "defaultValue": "#020617"
   },
   {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
     "description": "Border color for the autocomplete options overlay.",
     "name": "--fkt-autocomplete-options-border-color",
-    "reference": "--fkt-color-neutral-200",
+    "reference": "transparent",
     "component": "Options",
     "category": "Colors",
     "type": "color",
-    "defaultValue": "#e2e8f0"
+    "defaultValue": "transparent"
   },
   {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
     "description": "Border radius for the autocomplete options overlay.",
     "name": "--fkt-autocomplete-options-border-radius",
     "reference": "--fkt-radius-md",
@@ -36,6 +299,10 @@
     "defaultValue": ".375rem"
   },
   {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
     "description": "Box shadow for the autocomplete options overlay.",
     "name": "--fkt-autocomplete-options-shadow",
     "reference": "--fkt-shadow-md",
@@ -45,15 +312,23 @@
     "defaultValue": "0 4px 6px -1px var(--fkt-shadow-color-sm), 0 2px 4px -2px var(--fkt-shadow-color-md)"
   },
   {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
     "description": "Padding for each option item in the list.",
     "name": "--fkt-autocomplete-options-item-padding",
-    "reference": "var(--fkt-space-xs) var(--fkt-space-md)",
+    "reference": "--fkt-space-xs --fkt-space-md",
     "component": "Options",
     "category": "Spacing",
-    "type": "size",
-    "defaultValue": "var(--fkt-space-xs) var(--fkt-space-md)"
+    "type": "spacing",
+    "defaultValue": ".5rem 1rem"
   },
   {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
     "description": "Background color for option items on hover.",
     "name": "--fkt-autocomplete-options-item-hover-background",
     "reference": "--fkt-color-primary-opacity-10",
@@ -63,6 +338,10 @@
     "defaultValue": "rgba(55, 65, 81, 0.1)"
   },
   {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
     "description": "Gap between elements in option label container.",
     "name": "--fkt-autocomplete-options-label-gap",
     "reference": "--fkt-space-3xs",
@@ -72,42 +351,88 @@
     "defaultValue": ".25rem"
   },
   {
-    "description": "Color for success/check icons in options.",
-    "name": "--fkt-autocomplete-options-success-icon-color",
-    "reference": "--fkt-color-success",
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
+    "description": "Background color for selected options.",
+    "name": "--fkt-autocomplete-options-selected-background-color",
+    "reference": "--fkt-color-neutral-800",
     "component": "Options",
     "category": "Colors",
     "type": "color",
-    "defaultValue": "#00C950FF"
+    "defaultValue": "#1e293b"
   },
   {
-    "description": "Color for action icons in options.",
-    "name": "--fkt-autocomplete-options-icon-color",
-    "reference": "--fkt-color-neutral-700",
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
+    "description": "Text color for selected options.",
+    "name": "--fkt-autocomplete-options-selected-text-color",
+    "reference": "--fkt-color-neutral-50",
     "component": "Options",
     "category": "Colors",
     "type": "color",
-    "defaultValue": "#334155"
+    "defaultValue": "#f8fafc"
   },
   {
-    "description": "Size for action icons in options.",
-    "name": "--fkt-autocomplete-options-icon-size",
-    "reference": "--fkt-space-xl",
-    "component": "Options",
-    "category": "Spacing",
-    "type": "size",
-    "defaultValue": "1.5rem"
-  },
-  {
-    "description": "Minimum height for no results component.",
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
+    "description": "Minimum height for the empty state.",
     "name": "--fkt-autocomplete-options-no-results-min-height",
-    "reference": "0px",
+    "reference": "3.125rem",
     "component": "Options",
     "category": "Spacing",
     "type": "size",
-    "defaultValue": "0px"
+    "defaultValue": "3.125rem"
   },
   {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
+    "description": "Text color for the empty state.",
+    "name": "--fkt-autocomplete-options-no-results-text-color",
+    "reference": "--fkt-color-neutral-800",
+    "component": "Options",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#1e293b"
+  },
+  {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
+    "description": "Padding for group labels.",
+    "name": "--fkt-autocomplete-options-group-padding",
+    "reference": "--fkt-space-xs --fkt-space-xs",
+    "component": "Options",
+    "category": "Spacing",
+    "type": "spacing",
+    "defaultValue": ".5rem .5rem"
+  },
+  {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
+    "description": "Text color for group labels.",
+    "name": "--fkt-autocomplete-options-group-text-color",
+    "reference": "--fkt-color-neutral-600",
+    "component": "Options",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#475569"
+  },
+  {
+    "scope": {
+      "name": "Options",
+      "selector": "fkt-autocomplete-options"
+    },
     "description": "Padding for spinner container.",
     "name": "--fkt-autocomplete-options-spinner-padding",
     "reference": "--fkt-space-md",
@@ -115,5 +440,135 @@
     "category": "Spacing",
     "type": "size",
     "defaultValue": "1rem"
+  },
+  {
+    "scope": {
+      "name": "Chips",
+      "selector": "fkt-autocomplete-chips"
+    },
+    "description": "Background color for selected value chips.",
+    "name": "--fkt-autocomplete-chip-background-color",
+    "reference": "--fkt-color-neutral-300",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#cbd5e1",
+    "component": "Chips"
+  },
+  {
+    "scope": {
+      "name": "Chips",
+      "selector": "fkt-autocomplete-chips"
+    },
+    "description": "Text color for selected value chips.",
+    "name": "--fkt-autocomplete-chip-text-color",
+    "reference": "--fkt-color-neutral-700",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#334155",
+    "component": "Chips"
+  },
+  {
+    "scope": {
+      "name": "Chips",
+      "selector": "fkt-autocomplete-chips"
+    },
+    "description": "Background color for chips when hovered.",
+    "name": "--fkt-autocomplete-chip-hover-background-color",
+    "reference": "--fkt-color-neutral-400",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#94a3b8",
+    "component": "Chips"
+  },
+  {
+    "scope": {
+      "name": "Chips",
+      "selector": "fkt-autocomplete-chips"
+    },
+    "description": "Background color for disabled chips.",
+    "name": "--fkt-autocomplete-chip-disabled-background-color",
+    "reference": "--fkt-color-neutral-300",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#cbd5e1",
+    "component": "Chips"
+  },
+  {
+    "scope": {
+      "name": "Chips",
+      "selector": "fkt-autocomplete-chips"
+    },
+    "description": "Border color for disabled chips.",
+    "name": "--fkt-autocomplete-chip-disabled-border-color",
+    "reference": "--fkt-color-neutral-400",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#94a3b8",
+    "component": "Chips"
+  },
+  {
+    "scope": {
+      "name": "Chips",
+      "selector": "fkt-autocomplete-chips"
+    },
+    "description": "Text color for disabled chips.",
+    "name": "--fkt-autocomplete-chip-disabled-text-color",
+    "reference": "--fkt-color-neutral-500",
+    "category": "Colors",
+    "type": "color",
+    "defaultValue": "#64748b",
+    "component": "Chips"
+  },
+  {
+    "scope": {
+      "name": "Chips",
+      "selector": "fkt-autocomplete-chips"
+    },
+    "description": "Font size for selected value chips.",
+    "name": "--fkt-autocomplete-chip-font-size",
+    "reference": "--fkt-font-size-xs",
+    "category": "Typography",
+    "type": "size",
+    "defaultValue": "0.75rem",
+    "component": "Chips"
+  },
+  {
+    "scope": {
+      "name": "Chips",
+      "selector": "fkt-autocomplete-chips"
+    },
+    "description": "Padding inside selected value chips.",
+    "name": "--fkt-autocomplete-chip-padding",
+    "reference": "--fkt-space-4xs --fkt-space-xs",
+    "category": "Spacing",
+    "type": "spacing",
+    "defaultValue": ".125rem .5rem",
+    "component": "Chips"
+  },
+  {
+    "scope": {
+      "name": "Chips",
+      "selector": "fkt-autocomplete-chips"
+    },
+    "description": "Gap between the chip label and remove icon.",
+    "name": "--fkt-autocomplete-chip-gap",
+    "reference": "--fkt-space-3xs",
+    "category": "Spacing",
+    "type": "size",
+    "defaultValue": ".25rem",
+    "component": "Chips"
+  },
+  {
+    "scope": {
+      "name": "Chips",
+      "selector": "fkt-autocomplete-chips"
+    },
+    "description": "Border radius for selected value chips.",
+    "name": "--fkt-autocomplete-chip-border-radius",
+    "reference": "--fkt-radius-full",
+    "category": "Shape",
+    "type": "size",
+    "defaultValue": "9999px",
+    "component": "Chips"
   }
 ]

--- a/apps/docs/src/app/stories/autocomplete/fkt-autocomplete.docs.md
+++ b/apps/docs/src/app/stories/autocomplete/fkt-autocomplete.docs.md
@@ -127,9 +127,17 @@ The overlay accepts projected templates for advanced rendering:
 - `fktAutocompleteGroup`
 - `fktAutocompleteItem`
 - `fktAutocompleteFooter`
+- `fktAutocompleteChip`
+- `fktAutocompleteEmpty`
 
 Templates customize rendering only. Keyboard navigation, active descendant, selection, form value,
 and overlay behavior remain managed by the component.
+
+`fktAutocompleteChip` receives the normalized selected option. It replaces the chip content while
+the autocomplete keeps the removable button, disabled state, focus handling, and accessible label.
+
+`fktAutocompleteEmpty` receives an empty-state object containing `label`, `query`, `minSearch`, and
+`reason`. The reason is `min-search`, `query-no-results`, or `no-results`.
 
 ## Performance Directives
 

--- a/apps/docs/src/app/stories/autocomplete/fkt-autocomplete.stories.ts
+++ b/apps/docs/src/app/stories/autocomplete/fkt-autocomplete.stories.ts
@@ -262,8 +262,9 @@ export const HydratedValues: Story<AutocompleteHydratedValueExampleComponent> =
 export const Templates: StoryIntroduction = {};
 
 /**
- * Custom item, group, header, and footer templates. Template contexts expose the normalized option
- * and selection state, so custom UI remains type-safe while the form value stays primitive.
+ * Custom item, group, header, footer, chip, and empty-state templates. Template contexts expose
+ * normalized options and search state, so custom UI remains type-safe while the form value stays
+ * primitive. Chip templates preserve the built-in removal behavior and accessibility contract.
  */
 export const CustomContent: Story<AutocompleteCustomContentExampleComponent> = {
     component: AutocompleteCustomContentExampleComponent,

--- a/apps/docs/src/app/stories/color-picker/fkt-color-picker.docs.md
+++ b/apps/docs/src/app/stories/color-picker/fkt-color-picker.docs.md
@@ -110,8 +110,8 @@ Built-in support for multiple languages with extensible locale system:
 import {FKT_COLOR_PICKER_LOCALE_TOKEN} from 'frakton-ng/color-picker';
 import {inject} from '@angular/core';
 
-// Available locales: en, pt-br, es, fr
-// Default: pt-br (Brazilian Portuguese)
+// Available locales: en, de, pt-br, es, fr
+// Default: en (English)
 
 // Custom locale injection
 providers: [

--- a/apps/docs/src/app/stories/select/fkt-select-design-tokens.json
+++ b/apps/docs/src/app/stories/select/fkt-select-design-tokens.json
@@ -155,11 +155,11 @@
   {
     "description": "Padding for select options overlay items.",
     "name": "--fkt-select-options-item-padding",
-    "reference": "var(--fkt-space-xs) var(--fkt-space-md)",
+    "reference": "--fkt-space-xs --fkt-space-md",
     "component": "Options",
     "category": "Spacing",
-    "type": "size",
-    "defaultValue": "var(--fkt-space-xs) var(--fkt-space-md)"
+    "type": "spacing",
+    "defaultValue": ".5rem 1rem"
   },
   {
     "description": "Background color for hovered overlay items.",

--- a/apps/docs/src/app/stories/stories-map.ts
+++ b/apps/docs/src/app/stories/stories-map.ts
@@ -203,7 +203,7 @@ export const STORIES_MAP: StoryIndexer[] = [	{
 		        name: "CustomContent",
 		        type: "story",
 		        componentName: "AutocompleteCustomContentExampleComponent",
-		        description:  `Custom item, group, header, and footer templates. Template contexts expose the normalized option\nand selection state, so custom UI remains type-safe while the form value stays primitive.`,
+		        description:  `Custom item, group, header, footer, chip, and empty-state templates. Template contexts expose\nnormalized options and search state, so custom UI remains type-safe while the form value stays\nprimitive. Chip templates preserve the built-in removal behavior and accessibility contract.`,
 		        level: 3,
 		    },
 		    {

--- a/apps/docs/src/app/stories/table/fkt-table.stories.ts
+++ b/apps/docs/src/app/stories/table/fkt-table.stories.ts
@@ -562,6 +562,7 @@ export const Sorting: Story<TableExamplesSortingComponent> = {
  *     select: FktTableFilterSelectComponent,
  *     number: FktTableFilterNumberComponent,
  *     dateRange: FktTableFilterDateRangeComponent,
+ *     myCustomFilter: MyCustomFilterComponent
  * });
  * ```
  *
@@ -571,7 +572,7 @@ export const Sorting: Story<TableExamplesSortingComponent> = {
  * {
  *     key: 'name',
  *     header: 'Name',
- *     filter: filter.text('name', {
+ *     filter: filter.myCustomFilter('name', {
  *         label: 'Search',
  *     }),
  * }

--- a/apps/docs/src/app/stories/tag/fkt-tag-design-tokens.json
+++ b/apps/docs/src/app/stories/tag/fkt-tag-design-tokens.json
@@ -18,10 +18,10 @@
   {
     "description": "Padding for badge component.",
     "name": "--fkt-tag-padding",
-    "reference": "var(--fkt-space-3xs) var(--fkt-space-xs)",
+    "reference": "--fkt-space-3xs --fkt-space-xs",
     "category": "Spacing",
-    "type": "size",
-    "defaultValue": "var(--fkt-space-3xs) var(--fkt-space-xs)"
+    "type": "spacing",
+    "defaultValue": ".25rem .5rem"
   },
   {
     "description": "Font weight for badge text.",

--- a/libs/frakton-ng/autocomplete-old/src/options/fkt-autocomplete-options.component.scss
+++ b/libs/frakton-ng/autocomplete-old/src/options/fkt-autocomplete-options.component.scss
@@ -52,10 +52,10 @@ $options-shadow: var(--fkt-autocomplete-options-shadow, var(--fkt-shadow-md));
 /*
 Padding for each option item in the list.
 @name --fkt-autocomplete-options-item-padding
-@reference var(--fkt-space-xs) var(--fkt-space-md)
+@reference --fkt-space-xs --fkt-space-md
 @component Options
 @category Spacing
-@type size
+@type spacing
 */
 $options-item-padding: var(--fkt-autocomplete-options-item-padding, var(--fkt-space-xs) var(--fkt-space-md));
 

--- a/libs/frakton-ng/autocomplete/public-api.ts
+++ b/libs/frakton-ng/autocomplete/public-api.ts
@@ -5,6 +5,8 @@ export { FktAutocompleteOverlayDirective } from './src/directives/fkt-autocomple
 export { FktAutocompleteSelectionDirective } from './src/directives/fkt-autocomplete-selection.directive';
 
 export { FktAutocompleteItemDirective } from './src/directives/public/fkt-autocomplete-item.directive';
+export { FktAutocompleteChipDirective } from './src/directives/public/fkt-autocomplete-chip.directive';
+export { FktAutocompleteEmptyDirective } from './src/directives/public/fkt-autocomplete-empty.directive';
 export { FktAutocompleteFooterDirective } from './src/directives/public/fkt-autocomplete-footer.directive';
 export { FktAutocompleteGroupDirective } from './src/directives/public/fkt-autocomplete-group.directive';
 export { FktAutocompleteHeaderDirective } from './src/directives/public/fkt-autocomplete-header.directive';

--- a/libs/frakton-ng/autocomplete/src/components/chips/fkt-autocomplete-chips.component.html
+++ b/libs/frakton-ng/autocomplete/src/components/chips/fkt-autocomplete-chips.component.html
@@ -7,10 +7,17 @@
             (click)="selection.removeItem(item)"
             class="chip"
         >
-            <span>
-                {{ item.label }}
-            </span>
-            <fkt-icon name="x-circle"/>
+            @if (template()) {
+                <ng-container
+                    [ngTemplateOutlet]="template()!"
+                    [ngTemplateOutletContext]="getTemplateContext(item)"
+                />
+            } @else {
+                <span>
+                    {{ item.label }}
+                </span>
+                <fkt-icon name="x-circle"/>
+            }
         </button>
     }
 }

--- a/libs/frakton-ng/autocomplete/src/components/chips/fkt-autocomplete-chips.component.scss
+++ b/libs/frakton-ng/autocomplete/src/components/chips/fkt-autocomplete-chips.component.scss
@@ -1,3 +1,99 @@
+// <design-tokens>
+
+/* @scope Chips */
+
+/*
+Background color for selected value chips.
+@name --fkt-autocomplete-chip-background-color
+@reference --fkt-color-neutral-300
+@category Colors
+@type color
+*/
+$chip-background-color: var(--fkt-autocomplete-chip-background-color, var(--fkt-color-neutral-300));
+
+/*
+Text color for selected value chips.
+@name --fkt-autocomplete-chip-text-color
+@reference --fkt-color-neutral-700
+@category Colors
+@type color
+*/
+$chip-text-color: var(--fkt-autocomplete-chip-text-color, var(--fkt-color-neutral-700));
+
+/*
+Background color for chips when hovered.
+@name --fkt-autocomplete-chip-hover-background-color
+@reference --fkt-color-neutral-400
+@category Colors
+@type color
+*/
+$chip-hover-background-color: var(--fkt-autocomplete-chip-hover-background-color, var(--fkt-color-neutral-400));
+
+/*
+Background color for disabled chips.
+@name --fkt-autocomplete-chip-disabled-background-color
+@reference --fkt-color-neutral-300
+@category Colors
+@type color
+*/
+$chip-disabled-background-color: var(--fkt-autocomplete-chip-disabled-background-color, var(--fkt-color-neutral-300));
+
+/*
+Border color for disabled chips.
+@name --fkt-autocomplete-chip-disabled-border-color
+@reference --fkt-color-neutral-400
+@category Colors
+@type color
+*/
+$chip-disabled-border-color: var(--fkt-autocomplete-chip-disabled-border-color, var(--fkt-color-neutral-400));
+
+/*
+Text color for disabled chips.
+@name --fkt-autocomplete-chip-disabled-text-color
+@reference --fkt-color-neutral-500
+@category Colors
+@type color
+*/
+$chip-disabled-text-color: var(--fkt-autocomplete-chip-disabled-text-color, var(--fkt-color-neutral-500));
+
+/*
+Font size for selected value chips.
+@name --fkt-autocomplete-chip-font-size
+@reference --fkt-font-size-xs
+@category Typography
+@type size
+*/
+$chip-font-size: var(--fkt-autocomplete-chip-font-size, var(--fkt-font-size-xs));
+
+/*
+Padding inside selected value chips.
+@name --fkt-autocomplete-chip-padding
+@reference --fkt-space-4xs --fkt-space-xs
+@category Spacing
+@type spacing
+*/
+$chip-padding: var(--fkt-autocomplete-chip-padding, var(--fkt-space-4xs) var(--fkt-space-xs));
+
+/*
+Gap between the chip label and remove icon.
+@name --fkt-autocomplete-chip-gap
+@reference --fkt-space-3xs
+@category Spacing
+@type size
+*/
+$chip-gap: var(--fkt-autocomplete-chip-gap, var(--fkt-space-3xs));
+
+/*
+Border radius for selected value chips.
+@name --fkt-autocomplete-chip-border-radius
+@reference --fkt-radius-full
+@category Shape
+@type size
+*/
+$chip-border-radius: var(--fkt-autocomplete-chip-border-radius, var(--fkt-radius-full));
+
+// </design-tokens>
+
 :host {
     display: contents;
 }
@@ -5,25 +101,24 @@
 .chip {
     display: flex;
     align-items: center;
-    gap: var(--fkt-space-3xs);
-    font-size: var(--fkt-font-size-xs);
-    padding: var(--fkt-space-4xs) var(--fkt-space-xs);
-    padding-right: var(--fkt-space-4xs);
-    border-radius: var(--fkt-radius-full);
-    background: var(--fkt-color-neutral-300);
-    color: var(--fkt-color-neutral-700);
+    gap: $chip-gap;
+    font-size: $chip-font-size;
+    padding: $chip-padding;
+    border-radius: $chip-border-radius;
+    background: $chip-background-color;
+    color: $chip-text-color;
     outline: none;
     cursor: pointer;
     border: solid 1px transparent;
 
     &[disabled] {
         cursor: not-allowed;
-        background: var(--fkt-color-neutral-300);
-        border: solid 1px var(--fkt-color-neutral-400);
-        color: var(--fkt-color-neutral-500);
+        background: $chip-disabled-background-color;
+        border-color: $chip-disabled-border-color;
+        color: $chip-disabled-text-color;
 
         &:hover {
-            background: var(--fkt-color-neutral-300);
+            background: $chip-disabled-background-color;
         }
     }
 
@@ -36,6 +131,6 @@
     }
 
     &:hover {
-        background: color-mix(in srgb, var(--fkt-color-neutral-300), var(--fkt-color-neutral-400));
+        background: color-mix(in srgb, $chip-background-color, $chip-hover-background-color);
     }
 }

--- a/libs/frakton-ng/autocomplete/src/components/chips/fkt-autocomplete-chips.component.ts
+++ b/libs/frakton-ng/autocomplete/src/components/chips/fkt-autocomplete-chips.component.ts
@@ -1,19 +1,23 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, input, TemplateRef } from '@angular/core';
 import { FktIconComponent } from 'frakton-ng/icon';
 import { Generic } from 'frakton-ng/internal/types';
 import { injectCompatFormStateWithoutNative } from 'frakton-ng/internal/di';
 import { FktAutocompleteContextDirective } from '../../directives/fkt-autocomplete-context.directive';
 import { FktAutocompleteSelectionDirective } from '../../directives/fkt-autocomplete-selection.directive';
+import { NgTemplateOutlet } from '@angular/common';
+import { FktAutocompleteChipContext } from '../../fkt-autocomplete.types';
 
 @Component({
     selector: 'fkt-autocomplete-chips',
-    imports: [FktIconComponent],
+    imports: [FktIconComponent, NgTemplateOutlet],
     templateUrl: './fkt-autocomplete-chips.component.html',
     styleUrl: './fkt-autocomplete-chips.component.scss',
 })
 export class FktAutocompleteChipsComponent<
     Option extends Generic | string,
 > {
+    readonly template = input<TemplateRef<FktAutocompleteChipContext<Option>>>();
+
     protected readonly formState = injectCompatFormStateWithoutNative();
     protected readonly context = inject<FktAutocompleteContextDirective<Option>>(
         FktAutocompleteContextDirective
@@ -21,4 +25,10 @@ export class FktAutocompleteChipsComponent<
     protected readonly selection = inject<
         FktAutocompleteSelectionDirective<Option>
     >(FktAutocompleteSelectionDirective);
+
+    protected getTemplateContext(
+        option: FktAutocompleteChipContext<Option>['$implicit']
+    ): FktAutocompleteChipContext<Option> {
+        return { $implicit: option };
+    }
 }

--- a/libs/frakton-ng/autocomplete/src/directives/fkt-autocomplete-overlay.directive.ts
+++ b/libs/frakton-ng/autocomplete/src/directives/fkt-autocomplete-overlay.directive.ts
@@ -19,7 +19,7 @@ import { FktAutocompleteFooterDirective } from './public/fkt-autocomplete-footer
 import { FktAutocompleteSelectionDirective } from './fkt-autocomplete-selection.directive';
 import { FktAutocompleteStoreService } from '../services/fkt-autocomplete-store.service';
 import { FktAutocompleteContextDirective } from './fkt-autocomplete-context.directive';
-import { FktNoResults } from 'frakton-ng/no-results';
+import { FktAutocompleteEmptyDirective } from './public/fkt-autocomplete-empty.directive';
 
 @Directive({ selector: 'fkt-autocomplete[fktAutocompleteOverlay]' })
 export class FktAutocompleteOverlayDirective<Option extends Generic | string> {
@@ -42,6 +42,9 @@ export class FktAutocompleteOverlayDirective<Option extends Generic | string> {
     );
     private readonly footerTemplate = contentChild(
         FktAutocompleteFooterDirective
+    );
+    private readonly emptyTemplate = contentChild(
+        FktAutocompleteEmptyDirective
     );
 
     private readonly syncDropdownState = effect(() => {
@@ -70,6 +73,7 @@ export class FktAutocompleteOverlayDirective<Option extends Generic | string> {
                 itemTemplate: this.itemTemplate()?.template,
                 headerTemplate: this.headerTemplate()?.template,
                 footerTemplate: this.footerTemplate()?.template,
+                emptyTemplate: this.emptyTemplate()?.template,
                 select: (option) => {
                     this.selectionService.selectItem(option);
                     this.restoreFocus();
@@ -96,7 +100,12 @@ export class FktAutocompleteOverlayDirective<Option extends Generic | string> {
                 inheritDesignTokensFrom: this.elementRef.nativeElement,
                 distanceFromAnchor: '4px 0',
                 maxHeight: 'fit-content',
-                borderRadius: 'var(--fkt-radius-sm)',
+                borderRadius:
+                    'var(--fkt-autocomplete-options-border-radius, var(--fkt-radius-md))',
+                backgroundColor:
+                    'var(--fkt-autocomplete-options-background-color, var(--fkt-color-modal-background))',
+                boxShadow:
+                    'var(--fkt-autocomplete-options-shadow, var(--fkt-shadow-md))',
                 parentInjector: this.injector,
             },
         });

--- a/libs/frakton-ng/autocomplete/src/directives/public/fkt-autocomplete-chip.directive.ts
+++ b/libs/frakton-ng/autocomplete/src/directives/public/fkt-autocomplete-chip.directive.ts
@@ -1,0 +1,16 @@
+import { Directive, inject, TemplateRef } from '@angular/core';
+import { FktAutocompleteChipContext } from '../../fkt-autocomplete.types';
+
+@Directive({
+    selector: '[fktAutocompleteChip]',
+})
+export class FktAutocompleteChipDirective {
+    readonly template = inject(TemplateRef);
+
+    static ngTemplateContextGuard<T>(
+        _: FktAutocompleteChipDirective,
+        context: unknown
+    ): context is FktAutocompleteChipContext<T> {
+        return true;
+    }
+}

--- a/libs/frakton-ng/autocomplete/src/directives/public/fkt-autocomplete-empty.directive.ts
+++ b/libs/frakton-ng/autocomplete/src/directives/public/fkt-autocomplete-empty.directive.ts
@@ -1,0 +1,16 @@
+import { Directive, inject, TemplateRef } from '@angular/core';
+import { FktAutocompleteEmptyContext } from '../../fkt-autocomplete.types';
+
+@Directive({
+    selector: '[fktAutocompleteEmpty]',
+})
+export class FktAutocompleteEmptyDirective {
+    readonly template = inject(TemplateRef);
+
+    static ngTemplateContextGuard(
+        _: FktAutocompleteEmptyDirective,
+        context: unknown
+    ): context is FktAutocompleteEmptyContext {
+        return true;
+    }
+}

--- a/libs/frakton-ng/autocomplete/src/fkt-autocomplete.component.html
+++ b/libs/frakton-ng/autocomplete/src/fkt-autocomplete.component.html
@@ -10,7 +10,7 @@
          [attr.aria-controls]="context.listBoxId"
          fktCustomField>
         <div class="container" [class.multiple]="context.multiple()">
-            <fkt-autocomplete-chips/>
+            <fkt-autocomplete-chips [template]="chipDirective()?.template"/>
 
             <input
                 fktAutocompleteSearch

--- a/libs/frakton-ng/autocomplete/src/fkt-autocomplete.component.scss
+++ b/libs/frakton-ng/autocomplete/src/fkt-autocomplete.component.scss
@@ -1,3 +1,184 @@
+// <design-tokens>
+
+/* @scope Field */
+
+/*
+Vertical padding inside the input field (top and bottom spacing between border and content).
+@name --fkt-field-vertical-padding
+@reference --fkt-space-inset-3xs
+@category Spacing
+@type size
+ */
+$field-vertical-padding: var(--fkt-field-vertical-padding, var(--fkt-space-inset-3xs));
+
+/*
+Vertical padding inside the input field (top and bottom spacing between border and content).
+@name --fkt-field-vertical-padding-sm
+@reference --fkt-space-inset-4xs
+@category Spacing
+@type size
+ */
+$field-vertical-padding-sm: var(--fkt-field-vertical-padding-sm, var(--fkt-space-inset-4xs));
+
+/*
+Vertical padding inside the input field (top and bottom spacing between border and content).
+@name --fkt-field-vertical-padding-lg
+@reference --fkt-space-inset-2xs
+@category Spacing
+@type size
+ */
+$field-vertical-padding-lg: var(--fkt-field-vertical-padding-lg, var(--fkt-space-inset-2xs));
+
+/*
+Horizontal padding inside the input field (left and right spacing between border and content).
+@name --fkt-field-horizontal-padding
+@reference --fkt-space-inset-2xs
+@category Spacing
+@type size
+ */
+$field-horizontal-padding: var(--fkt-field-horizontal-padding, var(--fkt-space-inset-2xs));
+
+/*
+Horizontal padding inside the input field (left and right spacing between border and content).
+@name --fkt-field-horizontal-padding-sm
+@reference --fkt-space-inset-3xs
+@category Spacing
+@type size
+ */
+$field-horizontal-padding-sm: var(--fkt-field-horizontal-padding-sm, var(--fkt-space-inset-3xs));
+
+/*
+Horizontal padding inside the input field (left and right spacing between border and content).
+@name --fkt-field-horizontal-padding-lg
+@reference --fkt-space-inset-xs
+@category Spacing
+@type size
+ */
+$field-horizontal-padding-lg: var(--fkt-field-horizontal-padding-lg, var(--fkt-space-inset-xs));
+
+/*
+Border color of the input in its normal (default) state.
+@name --fkt-field-border-color
+@reference --fkt-color-neutral-400
+@category Colors
+@type color
+ */
+$border-color: var(--fkt-field-border-color, var(--fkt-color-neutral-400));
+
+/*
+Border color of the input when it gets focused
+@name --fkt-field-border-focus-color
+@reference --fkt-color-neutral-800
+@category Colors
+@type color
+ */
+$border-focus-color: var(--fkt-field-border-focus-color, var(--fkt-color-neutral-800));
+
+/*
+Color of the label in its normal (default) state.
+@name --fkt-field-label-color
+@reference --fkt-color-neutral-700
+@category Colors
+@type color
+ */
+$label-color: var(--fkt-field-label-color, var(--fkt-color-neutral-700));
+
+/*
+Color of the label when it gets focused
+@name --fkt-field-label-focus-color
+@reference --fkt-color-neutral-800
+@category Colors
+@type color
+ */
+$label-focus-color: var(--fkt-field-label-focus-color, var(--fkt-color-neutral-800));
+
+/*
+Border radius for input
+@name --fkt-field-border-radius
+@reference --fkt-radius-md
+@category Spacing
+@type size
+ */
+$border-radius: var(--fkt-field-border-radius, var(--fkt-radius-md));
+
+/*
+Font size for input text and placeholder.
+@name --fkt-field-font-size
+@reference --fkt-font-size-sm
+@category Typography
+@type size
+ */
+$font-size: var(--fkt-field-font-size, var(--fkt-font-size-sm));
+
+/*
+Font size for input text and placeholder.
+@name --fkt-field-font-size-sm
+@reference --fkt-font-size-xs
+@category Typography
+@type size
+ */
+$font-size-sm: var(--fkt-field-font-size-sm, var(--fkt-font-size-xs));
+
+/*
+Font size for input text and placeholder.
+@name --fkt-field-font-size-lg
+@reference --fkt-font-size-md
+@category Typography
+@type size
+ */
+$font-size-lg: var(--fkt-field-font-size-lg, var(--fkt-font-size-md));
+
+/*
+Color for text written into input
+@name --fkt-field-text-color
+@reference --fkt-color-neutral-900
+@category Colors
+@type color
+ */
+$text-color: var(--fkt-field-text-color, var(--fkt-color-neutral-900));
+
+/*
+Space between prefix and field element
+@name --fkt-field-prefix-gap
+@scope Prefix | [fktFieldPrefix]
+@reference --fkt-space-xs
+@category Spacing
+@type size
+ */
+$prefix-gap: var(--fkt-field-prefix-gap, var(--fkt-space-xs));
+
+/*
+Text color for prefix when field is at invalid state
+@name --fkt-field-prefix-invalid-text
+@scope Prefix | [fktFieldPrefix]
+@reference --fkt-color-danger
+@category Colors
+@type color
+ */
+$prefix-invalid-color: var(--fkt-field-prefix-invalid-text, var(--fkt-color-danger));
+
+/*
+Space between suffix and field element
+@name --fkt-field-suffix-gap
+@scope Suffix | [fktFieldSuffix]
+@reference --fkt-space-xs
+@category Spacing
+@type size
+ */
+$suffix-gap: var(--fkt-field-suffix-gap, var(--fkt-space-xs));
+
+/*
+Text color for suffix when field is at invalid state
+@name --fkt-field-suffix-invalid-text
+@scope Suffix | [fktFieldSuffix]
+@reference --fkt-color-danger
+@category Colors
+@type color
+ */
+$suffix-invalid-color: var(--fkt-field-suffix-invalid-text, var(--fkt-color-danger));
+
+// </design-tokens>
+
 :host ::ng-deep {
     .container {
         width: 100%;

--- a/libs/frakton-ng/autocomplete/src/fkt-autocomplete.component.ts
+++ b/libs/frakton-ng/autocomplete/src/fkt-autocomplete.component.ts
@@ -1,12 +1,10 @@
 import {
     AfterViewInit,
-    booleanAttribute,
     Component,
     computed,
     contentChild,
     effect,
     inject,
-    input,
     Optional,
     Self,
     viewChild,
@@ -34,6 +32,7 @@ import {
 } from './utils/normalize-written-autocomplete-value';
 import { FktAutocompleteChipsComponent } from './components/chips/fkt-autocomplete-chips.component';
 import { FktAutocompleteActionButtonComponent } from './components/action-button/fkt-autocomplete-action-button.component';
+import { FktAutocompleteChipDirective } from './directives/public/fkt-autocomplete-chip.directive';
 
 @Component({
     selector: 'fkt-autocomplete',
@@ -110,6 +109,9 @@ export class FktAutocompleteComponent<Option extends Generic | string>
     protected readonly errorDirective = contentChild(FktErrorDirective);
     protected readonly fieldPrefixDirective = contentChild(
         FktFieldPrefixDirective
+    );
+    protected readonly chipDirective = contentChild(
+        FktAutocompleteChipDirective
     );
 
     private onChange?: (value: FktAutocompleteValue) => void;

--- a/libs/frakton-ng/autocomplete/src/fkt-autocomplete.types.ts
+++ b/libs/frakton-ng/autocomplete/src/fkt-autocomplete.types.ts
@@ -57,6 +57,26 @@ export interface FktAutocompleteItemContext<Option = Generic> {
     isSelected: boolean;
 }
 
+export interface FktAutocompleteChipContext<Option = Generic> {
+    $implicit: FktAutocompleteOption<Option>;
+}
+
+export type FktAutocompleteEmptyReason =
+    | 'min-search'
+    | 'query-no-results'
+    | 'no-results';
+
+export interface FktAutocompleteEmptyState {
+    label: string;
+    query: string;
+    minSearch: number;
+    reason: FktAutocompleteEmptyReason;
+}
+
+export interface FktAutocompleteEmptyContext {
+    $implicit: FktAutocompleteEmptyState;
+}
+
 export interface FktAutocompleteGroupContext<Option = Generic> {
     $implicit: FktGroupedAutocompleteOption<Option>;
 }

--- a/libs/frakton-ng/autocomplete/src/options/fkt-autocomplete-options.component.html
+++ b/libs/frakton-ng/autocomplete/src/options/fkt-autocomplete-options.component.html
@@ -16,7 +16,9 @@
                 <fkt-spinner/>
             </div>
         } @else {
-            <div [style.height.px]="store.virtualData().range.topSpacerHeight"></div>
+            @if (store.virtualData().range.topSpacerHeight) {
+                <div [style.height.px]="store.virtualData().range.topSpacerHeight"></div>
+            }
             @for (group of store.virtualData().groups; track group.value) {
                 @if (group.label) {
                     @if (groupTemplate()) {
@@ -67,10 +69,19 @@
                 }
             } @empty {
                 <div class="no-results">
-                    {{ noResults().label }}
+                    @if (emptyTemplate()) {
+                        <ng-container
+                            [ngTemplateOutlet]="emptyTemplate()!"
+                            [ngTemplateOutletContext]="getEmptyTemplateContext(noResults())"
+                        />
+                    } @else {
+                        {{ noResults().label }}
+                    }
                 </div>
             }
-            <div [style.height.px]="store.virtualData().range.bottomSpacerHeight"></div>
+            @if (store.virtualData().range.bottomSpacerHeight) {
+                <div [style.height.px]="store.virtualData().range.bottomSpacerHeight"></div>
+            }
         }
     </ul>
 </fkt-infinite-loading>

--- a/libs/frakton-ng/autocomplete/src/options/fkt-autocomplete-options.component.scss
+++ b/libs/frakton-ng/autocomplete/src/options/fkt-autocomplete-options.component.scss
@@ -1,4 +1,7 @@
 // <design-tokens>
+
+/* @scope Options */
+
 /*
 Background color for the autocomplete options overlay.
 @name --fkt-autocomplete-options-background-color
@@ -22,12 +25,12 @@ $options-text-color: var(--fkt-autocomplete-options-text-color, var(--fkt-color-
 /*
 Border color for the autocomplete options overlay.
 @name --fkt-autocomplete-options-border-color
-@reference --fkt-color-neutral-200
+@reference transparent
 @component Options
 @category Colors
 @type color
 */
-$options-border-color: var(--fkt-autocomplete-options-border-color, var(--fkt-color-neutral-200));
+$options-border-color: var(--fkt-autocomplete-options-border-color, transparent);
 
 /*
 Border radius for the autocomplete options overlay.
@@ -52,10 +55,10 @@ $options-shadow: var(--fkt-autocomplete-options-shadow, var(--fkt-shadow-md));
 /*
 Padding for each option item in the list.
 @name --fkt-autocomplete-options-item-padding
-@reference var(--fkt-space-xs) var(--fkt-space-md)
+@reference --fkt-space-xs --fkt-space-md
 @component Options
 @category Spacing
-@type size
+@type spacing
 */
 $options-item-padding: var(--fkt-autocomplete-options-item-padding, var(--fkt-space-xs) var(--fkt-space-md));
 
@@ -80,44 +83,64 @@ Gap between elements in option label container.
 $options-label-gap: var(--fkt-autocomplete-options-label-gap, var(--fkt-space-3xs));
 
 /*
-Color for success/check icons in options.
-@name --fkt-autocomplete-options-success-icon-color
-@reference --fkt-color-success
+Background color for selected options.
+@name --fkt-autocomplete-options-selected-background-color
+@reference --fkt-color-neutral-800
 @component Options
 @category Colors
 @type color
 */
-$options-success-icon-color: var(--fkt-autocomplete-options-success-icon-color, var(--fkt-color-success));
+$options-selected-background-color: var(--fkt-autocomplete-options-selected-background-color, var(--fkt-color-neutral-800));
 
 /*
-Color for action icons in options.
-@name --fkt-autocomplete-options-icon-color
-@reference --fkt-color-neutral-700
+Text color for selected options.
+@name --fkt-autocomplete-options-selected-text-color
+@reference --fkt-color-neutral-50
 @component Options
 @category Colors
 @type color
 */
-$options-icon-color: var(--fkt-autocomplete-options-icon-color, var(--fkt-color-neutral-700));
+$options-selected-text-color: var(--fkt-autocomplete-options-selected-text-color, var(--fkt-color-neutral-50));
 
 /*
-Size for action icons in options.
-@name --fkt-autocomplete-options-icon-size
-@reference --fkt-space-xl
-@component Options
-@category Spacing
-@type size
-*/
-$options-icon-size: var(--fkt-autocomplete-options-icon-size, var(--fkt-space-xl));
-
-/*
-Minimum height for no results component.
+Minimum height for the empty state.
 @name --fkt-autocomplete-options-no-results-min-height
-@reference 0px
+@reference 3.125rem
 @component Options
 @category Spacing
 @type size
 */
-$options-no-results-min-height: var(--fkt-autocomplete-options-no-results-min-height, 0);
+$options-no-results-min-height: var(--fkt-autocomplete-options-no-results-min-height, 3.125rem);
+
+/*
+Text color for the empty state.
+@name --fkt-autocomplete-options-no-results-text-color
+@reference --fkt-color-neutral-800
+@component Options
+@category Colors
+@type color
+*/
+$options-no-results-text-color: var(--fkt-autocomplete-options-no-results-text-color, var(--fkt-color-neutral-800));
+
+/*
+Padding for group labels.
+@name --fkt-autocomplete-options-group-padding
+@reference --fkt-space-xs --fkt-space-xs
+@component Options
+@category Spacing
+@type spacing
+*/
+$options-group-padding: var(--fkt-autocomplete-options-group-padding, var(--fkt-space-xs) var(--fkt-space-xs));
+
+/*
+Text color for group labels.
+@name --fkt-autocomplete-options-group-text-color
+@reference --fkt-color-neutral-600
+@component Options
+@category Colors
+@type color
+*/
+$options-group-text-color: var(--fkt-autocomplete-options-group-text-color, var(--fkt-color-neutral-600));
 
 /*
 Padding for spinner container.
@@ -132,6 +155,7 @@ $options-spinner-padding: var(--fkt-autocomplete-options-spinner-padding, var(--
 
 :host {
     display: flex;
+    background-color: $options-background-color;
     flex-direction: column;
     width: 100%;
     color: $options-text-color;
@@ -145,44 +169,43 @@ $options-spinner-padding: var(--fkt-autocomplete-options-spinner-padding, var(--
 
 .no-results {
     font-size: var(--fkt-font-size-sm);
-    min-height: 50px;
+    min-height: $options-no-results-min-height;
     display: flex;
     justify-content: center;
     align-items: center;
-    color: var(--fkt-color-neutral-800);
+    color: $options-no-results-text-color;
 }
 
 .overlay {
     margin: 0;
-    background-color: $options-background-color;
     width: 100%;
     border-radius: $options-border-radius;
     overflow-y: auto;
     z-index: 10;
-    border: none;
     padding: 0;
     list-style: none;
 
     .group {
-        color: var(--fkt-color-neutral-600);
+        color: $options-group-text-color;
         font-size: var(--fkt-font-size-xs);
-        padding: var(--fkt-space-xs) 0;
+        padding: $options-group-padding;
         font-weight: var(--fkt-font-semibold);
     }
 
     .item {
         transition: var(--fkt-transition-slow);
         font-size: var(--fkt-font-size-sm);
+        border: 1px solid $options-border-color;
         box-sizing: border-box;
         cursor: pointer;
         display: flex;
         align-items: center;
-        padding: var(--fkt-space-xs);
+        padding: $options-item-padding;
         justify-content: space-between;
         border-radius: var(--fkt-radius-sm);
 
         &:hover {
-            background-color: color-mix(var(--fkt-color-neutral-200), var(--fkt-color-neutral-300));
+            background-color: $options-item-hover-background;
         }
 
         .label-container {
@@ -203,16 +226,16 @@ $options-spinner-padding: var(--fkt-autocomplete-options-spinner-padding, var(--
         }
 
         &.selected {
-            background: var(--fkt-color-neutral-800);
-            color: contrast-color(var(--fkt-color-neutral-800));
+            background: $options-selected-background-color;
+            color: $options-selected-text-color;
 
             &:hover {
-                background: var(--fkt-color-neutral-900);
+                background: color-mix(in srgb, $options-selected-background-color, black 12%);
             }
 
             fkt-icon {
                 font-size: var(--fkt-font-size-sm);
-                color: contrast-color(var(--fkt-color-neutral-800));
+                color: $options-selected-text-color;
                 font-weight: var(--fkt-font-semibold);
             }
         }
@@ -224,24 +247,19 @@ $options-spinner-padding: var(--fkt-autocomplete-options-spinner-padding, var(--
         border-radius: var(--fkt-radius-sm);
         padding-bottom: var(--fkt-space-3xs);
 
-        &:first-child {
-            padding-top: var(--fkt-space-3xs);
+        &:last-child {
+            padding-bottom: 0;
         }
 
         &.virtual-focused {
             .item {
-                background-color: color-mix(var(--fkt-color-neutral-200), var(--fkt-color-neutral-300));
+                background-color: $options-item-hover-background;
 
                 &.selected {
-                    background-color: color-mix(in srgb, var(--fkt-color-neutral-800), var(--fkt-color-neutral-400));
+                    background-color: color-mix(in srgb, $options-selected-background-color, white 24%);
                 }
             }
         }
-    }
-
-
-    fkt-no-results {
-        min-height: $options-no-results-min-height;
     }
 }
 

--- a/libs/frakton-ng/autocomplete/src/options/fkt-autocomplete-options.component.ts
+++ b/libs/frakton-ng/autocomplete/src/options/fkt-autocomplete-options.component.ts
@@ -13,9 +13,12 @@ import {
     viewChildren,
 } from '@angular/core';
 import { FktSpinnerComponent } from 'frakton-ng/spinner';
-import { FktNoResults } from 'frakton-ng/no-results';
 import { FktIconComponent } from 'frakton-ng/icon';
-import { FktAutocompleteOption } from '../fkt-autocomplete.types';
+import {
+    FktAutocompleteEmptyContext,
+    FktAutocompleteEmptyState,
+    FktAutocompleteOption,
+} from '../fkt-autocomplete.types';
 import { NgTemplateOutlet } from '@angular/common';
 import { CallPipe, TranslatePipe } from 'frakton-ng/internal/pipes';
 import { FktAutocompleteVirtualScrollDirective } from '../directives/public/fkt-autocomplete-virtual-scroll.directive';
@@ -55,6 +58,7 @@ export class FktAutocompleteOptionsComponent<Option extends Generic | string>
     groupTemplate = input<TemplateRef<any>>();
     headerTemplate = input<TemplateRef<any>>();
     footerTemplate = input<TemplateRef<any>>();
+    emptyTemplate = input<TemplateRef<FktAutocompleteEmptyContext>>();
 
     select = output<FktAutocompleteOption<Option>>();
 
@@ -79,12 +83,15 @@ export class FktAutocompleteOptionsComponent<Option extends Generic | string>
     );
 
     protected readonly noResults =
-        this.translator.translateComputed<FktNoResults>((t) => {
+        this.translator.translateComputed<FktAutocompleteEmptyState>((t) => {
             const query = this.store.query();
             const minSearch = this.context.minSearch();
 
             if (query.length < minSearch)
                 return {
+                    query,
+                    minSearch,
+                    reason: 'min-search',
                     label:
                         minSearch === 1
                             ? t('autocomplete.noResults.fewCharacters.singular')
@@ -95,15 +102,27 @@ export class FktAutocompleteOptionsComponent<Option extends Generic | string>
 
             if (query.length)
                 return {
+                    query,
+                    minSearch,
+                    reason: 'query-no-results',
                     label: t('autocomplete.noResults.notFoundForQuery.label', {
                         query,
                     }),
                 };
 
             return {
+                query,
+                minSearch,
+                reason: 'no-results',
                 label: t('autocomplete.noResults.noResultsAtAll.label'),
             };
         });
+
+    protected getEmptyTemplateContext(
+        state: FktAutocompleteEmptyState
+    ): FktAutocompleteEmptyContext {
+        return { $implicit: state };
+    }
 
     private readonly moveFocusToActiveElement = effect(() => {
         const index = this.store.activeDescendant.index();

--- a/libs/frakton-ng/field/src/fkt-field.component.scss
+++ b/libs/frakton-ng/field/src/fkt-field.component.scss
@@ -45,7 +45,7 @@ Horizontal padding inside the input field (left and right spacing between border
 @category Spacing
 @type size
  */
-$field-horizontal-padding-sm: var(--fkt-field-horizontal-padding, var(--fkt-space-inset-3xs));
+$field-horizontal-padding-sm: var(--fkt-field-horizontal-padding-sm, var(--fkt-space-inset-3xs));
 
 /*
 Horizontal padding inside the input field (left and right spacing between border and content).
@@ -54,7 +54,7 @@ Horizontal padding inside the input field (left and right spacing between border
 @category Spacing
 @type size
  */
-$field-horizontal-padding-lg: var(--fkt-field-horizontal-padding, var(--fkt-space-inset-xs));
+$field-horizontal-padding-lg: var(--fkt-field-horizontal-padding-lg, var(--fkt-space-inset-xs));
 
 /*
 Border color of the input in its normal (default) state.

--- a/libs/frakton-ng/select/src/options/fkt-select-options.component.scss
+++ b/libs/frakton-ng/select/src/options/fkt-select-options.component.scss
@@ -72,10 +72,10 @@ $options-border-color: var(--fkt-select-options-border-color, var(--fkt-color-ne
 /*
 Padding for select options overlay items.
 @name --fkt-select-options-item-padding
-@reference var(--fkt-space-xs) var(--fkt-space-md)
+@reference --fkt-space-xs --fkt-space-md
 @component Options
 @category Spacing
-@type size
+@type spacing
 */
 $options-item-padding: var(--fkt-select-options-item-padding, var(--fkt-space-xs) var(--fkt-space-md));
 

--- a/libs/frakton-ng/tag/src/fkt-tag.component.html
+++ b/libs/frakton-ng/tag/src/fkt-tag.component.html
@@ -1,5 +1,7 @@
 <div [class]="classes()">
-	<ng-content select="[tag-content]">
-		{{ text() }}
-	</ng-content>
+    <ng-content select="[tag-content]">
+        <div class="content">
+            {{ text() }}
+        </div>
+    </ng-content>
 </div>

--- a/libs/frakton-ng/tag/src/fkt-tag.component.scss
+++ b/libs/frakton-ng/tag/src/fkt-tag.component.scss
@@ -20,9 +20,9 @@ $tag-gap: var(--fkt-tag-gap, var(--fkt-space-xs));
 /*
 Padding for badge component.
 @name --fkt-tag-padding
-@reference var(--fkt-space-3xs) var(--fkt-space-xs)
+@reference --fkt-space-3xs --fkt-space-xs
 @category Spacing
-@type size
+@type spacing
 */
 $tag-padding: var(--fkt-tag-padding, var(--fkt-space-3xs) var(--fkt-space-xs));
 
@@ -190,68 +190,77 @@ $tag-success-faded-background: var(--fkt-tag-success-faded-background, var(--fkt
 // </design-tokens>
 
 .badge {
-	display: flex;
-	justify-content: center;
-	align-items: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
-	height: fit-content;
-	width: fit-content;
-	border-radius: $tag-border-radius;
+    height: fit-content;
+    width: fit-content;
+    border-radius: $tag-border-radius;
 
-	gap: $tag-gap;
-	padding: $tag-padding;
-	font-weight: $tag-font-weight;
-	font-size: $tag-font-size;
+    gap: $tag-gap;
+    padding: $tag-padding;
+    font-weight: $tag-font-weight;
+    font-size: $tag-font-size;
     white-space: nowrap;
 
-	&.badge--opaque {
-		&.badge--danger {
-			background-color: $tag-danger-background;
-			color: $tag-danger-color;
-		}
+    .content {
+        max-width: 100%;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        display: block;
+    }
 
-		&.badge--info {
-			background-color: $tag-info-background;
-			color: $tag-info-color;
-		}
 
-		&.badge--accent {
-			background-color: $tag-accent-background;
-			color: $tag-accent-color;
-		}
+    &.badge--opaque {
+        &.badge--danger {
+            background-color: $tag-danger-background;
+            color: $tag-danger-color;
+        }
 
-		&.badge--warning {
-			background-color: $tag-warning-background;
-			color: $tag-warning-color;
-		}
+        &.badge--info {
+            background-color: $tag-info-background;
+            color: $tag-info-color;
+        }
 
-		&.badge--success {
-			background-color: $tag-success-background;
-			color: $tag-success-color;
-		}
-	}
+        &.badge--accent {
+            background-color: $tag-accent-background;
+            color: $tag-accent-color;
+        }
 
-	&.badge--faded {
-		color: $tag-faded-text-color;
+        &.badge--warning {
+            background-color: $tag-warning-background;
+            color: $tag-warning-color;
+        }
 
-		&.badge--danger {
-			background-color: $tag-danger-faded-background;
-		}
+        &.badge--success {
+            background-color: $tag-success-background;
+            color: $tag-success-color;
+        }
+    }
 
-		&.badge--info {
-			background-color: $tag-info-faded-background;
-		}
+    &.badge--faded {
+        color: $tag-faded-text-color;
 
-		&.badge--warning {
-			background-color: $tag-warning-faded-background;
-		}
+        &.badge--danger {
+            background-color: $tag-danger-faded-background;
+        }
 
-		&.badge--accent {
-			background-color: $tag-accent-faded-background;
-		}
+        &.badge--info {
+            background-color: $tag-info-faded-background;
+        }
 
-		&.badge--success {
-			background-color: $tag-success-faded-background;
-		}
-	}
+        &.badge--warning {
+            background-color: $tag-warning-faded-background;
+        }
+
+        &.badge--accent {
+            background-color: $tag-accent-faded-background;
+        }
+
+        &.badge--success {
+            background-color: $tag-success-faded-background;
+        }
+    }
 }

--- a/scripts/story-indexer/tasks/design-tokens/design-token.models.ts
+++ b/scripts/story-indexer/tasks/design-tokens/design-token.models.ts
@@ -9,7 +9,14 @@ export interface DesignToken {
     category: string;
     description: string;
     component?: string;
-    type: 'size' | 'color' | 'font' | 'shadow' | 'weight' | 'opacity';
+    type:
+        | 'size'
+        | 'spacing'
+        | 'color'
+        | 'font'
+        | 'shadow'
+        | 'weight'
+        | 'opacity';
     defaultValue: string;
     scope?: DesignTokenScope;
 }

--- a/scripts/story-indexer/tasks/design-tokens/parse-design-token-file.ts
+++ b/scripts/story-indexer/tasks/design-tokens/parse-design-token-file.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { DesignToken, ParsedDesignTokenFile } from './design-token.models';
+import { resolveDesignTokenReference } from './resolve-design-token-reference';
 
 export const parseDesignTokenFile = (
     styleFilePath: string,
@@ -74,8 +75,10 @@ export const parseDesignTokenFile = (
             }
 
             if (object['reference']) {
-                object['defaultValue'] =
-                    globalTokens[object['reference']] ?? object['reference'];
+                object['defaultValue'] = resolveDesignTokenReference(
+                    object['reference'],
+                    globalTokens
+                );
             }
 
             if (scopeName && !object['component']) {

--- a/scripts/story-indexer/tasks/design-tokens/resolve-design-token-reference.ts
+++ b/scripts/story-indexer/tasks/design-tokens/resolve-design-token-reference.ts
@@ -1,0 +1,11 @@
+const DESIGN_TOKEN_NAME_PATTERN = /--[\w-]+/g;
+
+export const resolveDesignTokenReference = (
+    reference: string,
+    globalTokens: Record<string, string>
+) => {
+    return reference.replace(
+        DESIGN_TOKEN_NAME_PATTERN,
+        (tokenName) => globalTokens[tokenName] ?? tokenName
+    );
+};


### PR DESCRIPTION
## Summary
- expose typed autocomplete templates for selected chips and empty states while preserving built-in behavior and accessibility
- document and connect autocomplete, option, and chip design tokens to the rendered styles
- support compound design-token references and add a dedicated spacing editor with per-side controls
- split each design-token input type into a focused control component

## Impact
Consumers can customize chips and empty states without taking ownership of selection mechanics. Documentation authors can edit compound padding values through a compact control, and generated token metadata now resolves each global reference independently.

## Validation
- design-token task: 30 components, 63 style files, 394 tokens
- `node node_modules/nx/dist/bin/nx.js build docs --skip-nx-cache`
- 104 routes prerendered successfully

The build retains the existing PrismJS CommonJS optimization warning.