### PR TITLE
Fix/select adjustments in several components (#74)

### DIFF
--- a/apps/docs/src/app/app.config.ts
+++ b/apps/docs/src/app/app.config.ts
@@ -29,7 +29,7 @@ import {
     withFieldErrorMessages,
     withI18nIntegration,
 } from 'frakton-ng/core';
-import { TranslateService } from '@/core/services/translate.service';
+import { MyTranslateService } from '@/core/services/my-translate.service';
 
 export const appConfig: ApplicationConfig = {
     providers: [
@@ -37,7 +37,7 @@ export const appConfig: ApplicationConfig = {
         provideHttpClient(withFetch()),
         provideFktConfig(
             withI18nIntegration(() => {
-                const translateService = inject(TranslateService);
+                const translateService = inject(MyTranslateService);
 
                 return {
                     recomputeOn: translateService.currentLanguage$,

--- a/apps/docs/src/app/components/control-type-editor-table-cell/control-type-editor-cell.component.html
+++ b/apps/docs/src/app/components/control-type-editor-table-cell/control-type-editor-cell.component.html
@@ -12,6 +12,8 @@
         <fkt-select
             [hideLabel]="!showLabel()"
             [value]="value()"
+            labelKey="label"
+            valueKey="value"
             (valueChange)="update.emit($event)"
             [label]="name()"
             [options]="(options() ?? []) | stringToSelectOptions"/>

--- a/apps/docs/src/app/components/playground/components/panel/story-panel.component.html
+++ b/apps/docs/src/app/components/playground/components/panel/story-panel.component.html
@@ -101,6 +101,8 @@
                                             @case ('select') {
                                                 <fkt-select
                                                     hideLabel
+                                                    labelKey="label"
+                                                    valueKey="value"
                                                     [label]="arg.name"
                                                     [options]="arg.options"
                                                     [(value)]="arg.control"

--- a/apps/docs/src/app/core/services/my-translate.service.ts
+++ b/apps/docs/src/app/core/services/my-translate.service.ts
@@ -68,7 +68,7 @@ function translate(
 }
 
 @Injectable({ providedIn: 'root' })
-export class TranslateService {
+export class MyTranslateService {
     currentLanguage$ = new BehaviorSubject('en');
 
     setLanguage(language: string) {

--- a/apps/docs/src/app/stories/field/examples/translated-errors/field-translated-errors-example.component.html
+++ b/apps/docs/src/app/stories/field/examples/translated-errors/field-translated-errors-example.component.html
@@ -1,6 +1,8 @@
 <fkt-select
     [formField]="language"
     label="Language"
+    labelKey="label"
+    valueKey="value"
     placeholder="Select a language"
     [options]="languageOptions"
 />

--- a/apps/docs/src/app/stories/field/examples/translated-errors/field-translated-errors-example.component.ts
+++ b/apps/docs/src/app/stories/field/examples/translated-errors/field-translated-errors-example.component.ts
@@ -7,7 +7,7 @@ import {
     minLength,
     required,
 } from '@angular/forms/signals';
-import { TranslateService } from '@/core/services/translate.service';
+import { MyTranslateService } from '@/core/services/my-translate.service';
 import { FktFieldComponent, FktFieldPrefixDirective } from 'frakton-ng/field';
 import { FktInputTextDirective } from 'frakton-ng/input-text';
 import { FktIconComponent } from 'frakton-ng/icon';
@@ -27,7 +27,7 @@ import { FktSelectComponent, FktSelectOption } from 'frakton-ng/select';
     styleUrl: './field-translated-errors-example.component.scss',
 })
 export class FieldTranslatedErrorsExampleComponent {
-    private translate = inject(TranslateService);
+    private translate = inject(MyTranslateService);
 
     private model = signal({
         name: '',
@@ -36,7 +36,7 @@ export class FieldTranslatedErrorsExampleComponent {
         email: '',
     });
 
-    private selectedLanguage = signal('en-US');
+    private selectedLanguage = signal('en');
 
     protected form = form(this.model, (schema) => {
         required(schema.name);

--- a/apps/docs/src/app/stories/focus-trap/examples/form-example/fkt-focus-trap-form-example.component.html
+++ b/apps/docs/src/app/stories/focus-trap/examples/form-example/fkt-focus-trap-form-example.component.html
@@ -16,6 +16,8 @@
 
     <fkt-select
       label="Country"
+      labelKey="label"
+      valueKey="value"
       placeholder="Select your country"
       [options]="countryOptions()"
     />

--- a/apps/docs/src/app/stories/table/examples/stateful/table-examples-stateful.component.ts
+++ b/apps/docs/src/app/stories/table/examples/stateful/table-examples-stateful.component.ts
@@ -140,6 +140,8 @@ export class TableExamplesStatefulComponent {
                 }),
             filter: filter.select('status', {
                 label: 'Status',
+                labelKey: 'label',
+                valueKey: 'value',
                 options: Object.entries(STATUS_INFO).map(([value, info]) => ({
                     label: info.label,
                     value,

--- a/apps/docs/src/app/stories/table/examples/with-filtering/table-examples-filtering.component.ts
+++ b/apps/docs/src/app/stories/table/examples/with-filtering/table-examples-filtering.component.ts
@@ -14,7 +14,6 @@ import {
 } from 'frakton-ng/table';
 import { FktNoResults } from 'frakton-ng/no-results';
 import { FktTagComponent } from 'frakton-ng/tag';
-import { FktSpinnerComponent } from 'frakton-ng/spinner';
 import { FktButtonsListComponent } from 'frakton-ng/buttons-list';
 import { FktTableFilterTextComponent } from 'frakton-ng/table/filters/text';
 import { FktTableFilterSelectComponent } from 'frakton-ng/table/filters/select';
@@ -95,6 +94,8 @@ export class TableExamplesFilteringComponent {
             header: 'Category',
             filter: filter.select('category', {
                 label: 'Category',
+                labelKey: 'label',
+                valueKey: 'value',
                 options: [
                     { value: 'Electronics', label: 'Electronics' },
                     { value: 'Clothing', label: 'Clothing' },
@@ -136,6 +137,8 @@ export class TableExamplesFilteringComponent {
             header: 'Status',
             filter: filter.select('status', {
                 label: 'Status',
+                labelKey: 'label',
+                valueKey: 'value',
                 options: [
                     { value: 'available', label: 'Available' },
                     { value: 'low_stock', label: 'Low stock' },

--- a/libs/frakton-ng/paginator/src/fkt-paginator.component.html
+++ b/libs/frakton-ng/paginator/src/fkt-paginator.component.html
@@ -69,9 +69,12 @@
 		<div class="pagination__page-size">
 			<fkt-select
 				[value]="pageSize()"
+                (valueChange)="changePageSize($event)"
+                labelKey="label"
+                hideClearButton
+                valueKey="value"
 				[options]="pageSizeOptions()"
 				[disabled]="disabled()"
-				(valueChange)="changePageSize($event)"
 				label="Items per page"
 			/>
 		</div>

--- a/libs/frakton-ng/paginator/src/fkt-paginator.component.scss
+++ b/libs/frakton-ng/paginator/src/fkt-paginator.component.scss
@@ -107,6 +107,7 @@ $mobile-breakpoint: var(--fkt-pagination-mobile-breakpoint, 640px);
 	&__page-size {
 		display: flex;
 		align-items: center;
+        width: 110px;
 		gap: $page-size-gap;
 
 	}
@@ -133,8 +134,3 @@ $mobile-breakpoint: var(--fkt-pagination-mobile-breakpoint, 640px);
 	}
 }
 
-fkt-select {
-    --fkt-select-vertical-padding: var(--fkt-space-xs);
-    --fkt-select-horizontal-padding: var(--fkt-space-xs);
-    --fkt-select-font-size: var(--fkt-font-size-sm);
-}

--- a/libs/frakton-ng/paginator/src/fkt-paginator.component.ts
+++ b/libs/frakton-ng/paginator/src/fkt-paginator.component.ts
@@ -5,116 +5,121 @@ import {
     DEFAULT_PAGINATOR_CONFIG,
     FktPaginatorConfig,
 } from './fkt-paginator.types';
+import { FktFieldSuffixDirective } from 'frakton-ng/field';
 
 @Component({
-	selector: 'fkt-paginator',
-	imports: [
-		FktButtonComponent,
-		FktSelectComponent
-	],
-	templateUrl: './fkt-paginator.component.html',
-	styleUrl: './fkt-paginator.component.scss'
+    selector: 'fkt-paginator',
+    imports: [FktButtonComponent, FktSelectComponent, FktFieldSuffixDirective],
+    templateUrl: './fkt-paginator.component.html',
+    styleUrl: './fkt-paginator.component.scss',
 })
 export class FktPaginatorComponent {
-	page = model(1);
-	pageSize = model(10);
-	total = input.required<number>();
-	config = input<FktPaginatorConfig>({});
-	disabled = input<boolean>(false);
+    page = model(1);
+    pageSize = model(10);
+    total = input.required<number>();
+    config = input<FktPaginatorConfig>({});
+    disabled = input<boolean>(false);
 
-	protected mergedConfig = computed(() => ({
-		...DEFAULT_PAGINATOR_CONFIG,
-		...this.config()
-	}));
+    protected mergedConfig = computed(() => ({
+        ...DEFAULT_PAGINATOR_CONFIG,
+        ...this.config(),
+    }));
 
-	protected totalPages = computed(() => {
-		return Math.ceil(this.total() / this.pageSize());
-	});
+    protected totalPages = computed(() => {
+        return Math.ceil(this.total() / this.pageSize());
+    });
 
-	protected currentPage = computed(() => this.page());
+    protected currentPage = computed(() => this.page());
 
-	protected startItem = computed(() => {
-		return (this.page() - 1) * this.pageSize() + 1;
-	});
+    protected startItem = computed(() => {
+        return (this.page() - 1) * this.pageSize() + 1;
+    });
 
-	protected endItem = computed(() => {
-		return Math.min(this.page() * this.pageSize(), this.total());
-	});
+    protected endItem = computed(() => {
+        return Math.min(this.page() * this.pageSize(), this.total());
+    });
 
-	protected visiblePages = computed(() => {
-		const totalPages = this.totalPages();
-		const currentPage = this.currentPage();
-		const maxVisible = this.mergedConfig().maxVisiblePages;
+    protected visiblePages = computed(() => {
+        const totalPages = this.totalPages();
+        const currentPage = this.currentPage();
+        const maxVisible = this.mergedConfig().maxVisiblePages;
 
-		if (totalPages <= maxVisible) {
-			return Array.from({ length: totalPages }, (_, i) => i + 1);
-		}
+        if (totalPages <= maxVisible) {
+            return Array.from({ length: totalPages }, (_, i) => i + 1);
+        }
 
-		const half = Math.floor(maxVisible / 2);
-		let start = Math.max(1, currentPage - half);
-		const end = Math.min(totalPages, start + maxVisible - 1);
+        const half = Math.floor(maxVisible / 2);
+        let start = Math.max(1, currentPage - half);
+        const end = Math.min(totalPages, start + maxVisible - 1);
 
-		if (end - start + 1 < maxVisible) {
-			start = Math.max(1, end - maxVisible + 1);
-		}
+        if (end - start + 1 < maxVisible) {
+            start = Math.max(1, end - maxVisible + 1);
+        }
 
-		return Array.from({ length: end - start + 1 }, (_, i) => start + i);
-	});
+        return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+    });
 
     protected firstIsVisible = computed(() => {
         return this.visiblePages().includes(1);
-    })
+    });
 
     protected lastIsVisible = computed(() => {
         return this.visiblePages().includes(this.totalPages());
-    })
+    });
 
-	protected pageSizeOptions = computed(() => {
-		const options = this.mergedConfig().pageSizeOptions;
-		return options.map(size => ({
-			label: `${size} items`,
-			value: size
-		}));
-	});
+    protected pageSizeOptions = computed(() => {
+        const options = this.mergedConfig().pageSizeOptions;
+        return options.map((size) => ({
+            label: `${size} items`,
+            value: size,
+        }));
+    });
 
-	protected canGoPrevious = computed(() => this.currentPage() > 1);
-	protected canGoNext = computed(() => this.currentPage() < this.totalPages());
+    protected canGoPrevious = computed(() => this.currentPage() > 1);
+    protected canGoNext = computed(
+        () => this.currentPage() < this.totalPages()
+    );
 
-	goToPage(page: number): void {
-		if (page < 1 || page > this.totalPages() || page === this.currentPage() || this.disabled()) {
-			return;
-		}
+    goToPage(page: number): void {
+        if (
+            page < 1 ||
+            page > this.totalPages() ||
+            page === this.currentPage() ||
+            this.disabled()
+        ) {
+            return;
+        }
 
-		this.page.set(page)
-	}
+        this.page.set(page);
+    }
 
-	goToFirst(): void {
-		this.goToPage(1);
-	}
+    goToFirst(): void {
+        this.goToPage(1);
+    }
 
-	goToLast(): void {
-		this.goToPage(this.totalPages());
-	}
+    goToLast(): void {
+        this.goToPage(this.totalPages());
+    }
 
-	goToPrevious(): void {
-		this.goToPage(this.currentPage() - 1);
-	}
+    goToPrevious(): void {
+        this.goToPage(this.currentPage() - 1);
+    }
 
-	goToNext(): void {
-		this.goToPage(this.currentPage() + 1);
-	}
+    goToNext(): void {
+        this.goToPage(this.currentPage() + 1);
+    }
 
-	changePageSize(newPageSize: FktSelectValue): void {
-        if(typeof newPageSize !== 'number') return;
+    changePageSize(newPageSize: FktSelectValue): void {
+        if (typeof newPageSize !== 'number') return;
 
-		if (newPageSize === this.pageSize() || this.disabled()) {
-			return;
-		}
+        if (newPageSize === this.pageSize() || this.disabled()) {
+            return;
+        }
 
-		const currentItem = this.startItem();
-		const newPage = Math.ceil(currentItem / newPageSize);
+        const currentItem = this.startItem();
+        const newPage = Math.ceil(currentItem / newPageSize);
 
         this.page.set(newPage);
-		this.pageSize.set(newPageSize);
-	}
+        this.pageSize.set(newPageSize);
+    }
 }

--- a/libs/frakton-ng/table/filters/select/fkt-table-filter-select.component.html
+++ b/libs/frakton-ng/table/filters/select/fkt-table-filter-select.component.html
@@ -2,6 +2,8 @@
     [label]="label()"
     [placeholder]="placeholder() ?? ''"
     [(value)]="internalValue"
+    [valueKey]="valueKey()"
+    [labelKey]="labelKey()"
     [options]="options()"/>
 <fkt-buttons-list
     [horizontalAlignment]="'end'"

--- a/libs/frakton-ng/table/filters/select/fkt-table-filter-select.component.ts
+++ b/libs/frakton-ng/table/filters/select/fkt-table-filter-select.component.ts
@@ -1,8 +1,19 @@
-import { ChangeDetectionStrategy, Component, input, linkedSignal, output } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    input,
+    linkedSignal,
+    output,
+} from '@angular/core';
 import { FktButtonsListComponent } from 'frakton-ng/buttons-list';
 import { FktButtonAction } from 'frakton-ng/button';
-import { FktSelectComponent, FktSelectOption } from 'frakton-ng/select';
+import {
+    FktSelectComponent,
+    FktSelectLabelKey,
+    FktSelectValueKey,
+} from 'frakton-ng/select';
 import { FktTableCustomFilter } from 'frakton-ng/table';
+import { Distribute, Generic } from 'frakton-ng/internal/types';
 
 @Component({
     selector: 'fkt-table-filter-select',
@@ -11,12 +22,16 @@ import { FktTableCustomFilter } from 'frakton-ng/table';
     styleUrl: './fkt-table-filter-select.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FktTableFilterSelectComponent implements FktTableCustomFilter<string | number | null> {
+export class FktTableFilterSelectComponent<T extends Generic | string | number>
+    implements FktTableCustomFilter<string | number | null>
+{
     label = input.required<string>();
     placeholder = input<string>();
     value = input.required<string | number | null>();
     defaultValue = input<string | number | null>();
-    options = input.required<FktSelectOption[]>();
+    options = input.required<Distribute<T>>();
+    labelKey = input.required<FktSelectLabelKey<T>>();
+    valueKey = input.required<FktSelectValueKey<T>>();
     cancel = output();
     apply = output<string | number | null>();
 


### PR DESCRIPTION
* feat(paginator): include FktFieldSuffixDirective and improve page-size select

- add import and include FktFieldSuffixDirective in component imports
- move (valueChange) binding to select root and add labelKey/valueKey
- hide clear button on page-size select to avoid empty values
- add fixed width (110px) to .pagination__page-size for consistent layout
- remove local fkt-select CSS overrides from component stylesheet
- tighten changePageSize: guard non-number values and early return
- apply consistent formatting (spaces, trailing commas, semicolons)
- minor template and computed-property whitespace/line-break cleanup
- hint used to shape message: {hint}

* feat(table/filter-select): support generic select options and label/value keys

- Add generic type parameter T to FktTableFilterSelectComponent to enable typed option data instead of the concrete FktSelectOption type.
- Replace options input type with Distribute<T> and add labelKey / valueKey inputs typed as FktSelectLabelKey<T> and FktSelectValueKey<T>.
- Wire labelKey and valueKey through the template so the FktSelectComponent receives the custom keys at runtime.
- Import Generic and Distribute from frakton-ng/internal/types and tidy up multi-line imports for readability.
- Preserve existing inputs and outputs (value, defaultValue, cancel, apply) to maintain current behavior while improving type safety and flexibility.

* docs(table): add labelKey/valueKey to select filters in examples

- Add labelKey and valueKey to category and status select filters in the with-filtering example so option objects map correctly to the select component.
- Add labelKey and valueKey to the status select in the stateful example where options are generated from STATUS_INFO.
- Remove unused FktSpinnerComponent import from the with-filtering example to clean up imports.
- These changes correct example configuration in apps/docs and avoid a stray unused import; no runtime behavior changes expected.

* refactor(i18n): rename TranslateService to MyTranslateService

- Rename TranslateService to MyTranslateService and rename the file apps/docs/src/app/core/services/translate.service.ts to apps/docs/src/app/core/services/my-translate.service.ts.
- Update imports and DI usage in apps/docs to inject MyTranslateService: app.config.ts and the field-translated-errors example component.
- Change example selected language value from 'en-US' to 'en' to align with the service default currentLanguage$.
- Add labelKey and valueKey attributes to the fkt-select in the translated-errors example template to correctly map option fields.
- Ensure recomputeOn still uses translateService.currentLanguage$ so translated error messages update when the language changes.
- BREAKING CHANGE: callers importing or injecting TranslateService must update imports and references to MyTranslateService and the new file path.
- hint: {hint}

* fix(control-type-editor): pass labelKey and valueKey to fkt-select

- Add labelKey="label" and valueKey="value" attributes to the fkt-select element in control-type-editor-cell.component.html.
- Ensure the select maps option objects' label and value properties so options produced by stringToSelectOptions (or object-based options) display and select correctly.
- Preserve existing bindings (hideLabel, value, valueChange, label, options); this is a template-only change to improve mapping behavior.
- Hint: {hint}

* fix(playground): pass labelKey and valueKey to fkt-select

- Add labelKey="label" and valueKey="value" to the <fkt-select> used in the playground story-panel so option object properties are mapped correctly.
- This ensures the select uses the "label" and "value" keys from arg.options and prevents incorrect label/value resolution in the docs playground controls.
- Affected file: apps/docs/src/app/components/playground/components/panel/ story-panel.component.html

* docs(focus-trap): add labelKey and valueKey to select in form example

- Add labelKey="label" and valueKey="value" attributes to the <fkt-select> in the focus-trap form example so option objects are mapped correctly for display and value.
- Prevents incorrect rendering or missing values when options are provided as objects with label/value keys in the docs story.
- Changed file: apps/docs/src/app/stories/focus-trap/examples/form-example/ fkt-focus-trap-form-example.component.html
- hint: {hint}